### PR TITLE
request from a dummy domain

### DIFF
--- a/frame/bridge/eth/offchain/src/lib.rs
+++ b/frame/bridge/eth/offchain/src/lib.rs
@@ -1,8 +1,8 @@
 //! Module to relay blocks from Ethereum Network
 //!
 //! In this module,
-//! the offchain worker will keep fetch the next block info and relay to Darwinia Network
-//! worker will fetch blocks from a nonexistent domain, ie http://eth-resource/,
+//! the offchain worker will keep fetch the next block info and relay to Darwinia Network.
+//! The worker will fetch blocks from a nonexistent domain, ie http://eth-resource/,
 //! such that it can be proxy to any source and do any reprocessing or cache on the node.
 //! Now the source may be EtherScan, Cloudflare Ethereum Gateway, or a Ethereum full node.
 //! Please our anothre project, darwinia.js.

--- a/frame/bridge/eth/offchain/src/lib.rs
+++ b/frame/bridge/eth/offchain/src/lib.rs
@@ -37,9 +37,9 @@ mod mock;
 #[cfg(all(feature = "std", test))]
 mod tests;
 #[cfg(feature = "easy-testing")]
-static ETHRESOUTCE: &'static [u8] = b"https://cloudflare-eth.com/";
+static ETHRESOURCE: &'static [u8] = b"https://cloudflare-eth.com/";
 #[cfg(not(feature = "easy-testing"))]
-static ETHRESOUTCE: &'static [u8] = b"http://eth-resource";
+static ETHRESOURCE: &'static [u8] = b"http://eth-resource";
 
 // --- core ---
 use core::str::from_utf8;
@@ -190,7 +190,7 @@ impl<T: Trait> Module<T> {
 			.to_vec();
 		payload.append(&mut base_n_bytes(target_number, 16));
 		payload.append(&mut r#"",false],"id":1}"#.as_bytes().to_vec());
-		let header = Self::fetch_header(ETHRESOUTCE.to_vec(), payload)?;
+		let header = Self::fetch_header(ETHRESOURCE.to_vec(), payload)?;
 
 		Self::submit_header(header);
 		Ok(())

--- a/frame/bridge/eth/offchain/src/lib.rs
+++ b/frame/bridge/eth/offchain/src/lib.rs
@@ -36,6 +36,10 @@ pub mod crypto {
 mod mock;
 #[cfg(all(feature = "std", test))]
 mod tests;
+#[cfg(feature = "easy-testing")]
+static ETHRESOUTCE: &'static [u8] = b"https://cloudflare-eth.com/";
+#[cfg(not(feature = "easy-testing"))]
+static ETHRESOUTCE: &'static [u8] = b"http://eth-resource";
 
 // --- core ---
 use core::str::from_utf8;
@@ -186,7 +190,7 @@ impl<T: Trait> Module<T> {
 			.to_vec();
 		payload.append(&mut base_n_bytes(target_number, 16));
 		payload.append(&mut r#"",false],"id":1}"#.as_bytes().to_vec());
-		let header = Self::fetch_header("http://eth-resource".as_bytes().to_vec(), payload)?;
+		let header = Self::fetch_header(ETHRESOUTCE.to_vec(), payload)?;
 
 		Self::submit_header(header);
 		Ok(())

--- a/frame/bridge/eth/offchain/src/tests.rs
+++ b/frame/bridge/eth/offchain/src/tests.rs
@@ -2,18 +2,6 @@
 use crate::*;
 
 #[test]
-fn url_decode() {
-	let mut raw_url = ethscan_url::GET_BLOCK.to_vec();
-	raw_url.append(&mut base_n_bytes(9725369, 16));
-	raw_url.append(&mut "&boolean=true&apikey=".as_bytes().to_vec());
-	let url = core::str::from_utf8(&raw_url).unwrap();
-	assert_eq!(
-		url,
-		"https://api.etherscan.io/api?module=proxy&action=eth_getBlockByNumber&tag=0x9465B9&boolean=true&apikey=",
-	);
-}
-
-#[test]
 fn test_build_eth_header_from_response() {
 	for resp in [REAL_ETHER_SCAN_API_RESPONSE1, REAL_ETHER_SCAN_API_RESPONSE2].iter() {
 		let raw_header = from_utf8(&resp[33..resp.len() - 1]).unwrap_or_default();


### PR DESCRIPTION
- fetch ethereum header a nonexist domain, such that the offchain worker is ready to be adapted by darwinia.js
- use easy-testing feature to change url to `https://cloudflare-eth.com/`
- fix #74 