### PR TITLE
More strict check for EthHeader PartialEq

### DIFF
--- a/primitives/eth-primitives/src/header.rs
+++ b/primitives/eth-primitives/src/header.rs
@@ -159,8 +159,11 @@ impl Default for EthHeader {
 impl PartialEq for EthHeader {
 	fn eq(&self, c: &EthHeader) -> bool {
 		if let (&Some(ref h1), &Some(ref h2)) = (&self.hash, &c.hash) {
-			if h1 == h2 {
-				return true;
+			// More strict check even if hashes equal since EthHeader could be decoded from dispatch call by external
+			// Note that this is different implementation compared to Open Ethereum
+			// Refer: https://github.com/openethereum/openethereum/blob/v3.0.0-alpha.1/ethcore/types/src/header.rs#L93
+			if h1 != h2 {
+				return false;
 			}
 		}
 


### PR DESCRIPTION
More strict check even if hashes equal since EthHeader could be decoded from dispatch call by external

Closes #59 