### PR TITLE
Relayer Game Event

### DIFF
--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -34,8 +34,8 @@ pub mod impls {
 				unimplemented!()
 			}
 
-			fn update_samples(_round: Round, samples: &mut Vec<Self::TcBlockNumber>) {
-				samples.push(samples.last().unwrap() - 1);
+			fn update_samples(samples: &mut Vec<Vec<Self::TcBlockNumber>>) {
+				samples.push(vec![samples.last().unwrap().last().unwrap() - 1]);
 			}
 
 			fn estimate_bond(round: Round, proposals_count: u64) -> Self::Balance {

--- a/frame/bridge/relayer-game/README.md
+++ b/frame/bridge/relayer-game/README.md
@@ -9,6 +9,51 @@
 
 ---
 
+### POC Version
+
+1. **Round 0, Target 4**
+	```
+	                  R3
+	                /   \
+	               c     f
+	              / \   / \
+	             a   b d   e
+	Block Number 0   1 2   3
+
+	This Proposal Say: I think the MMR Root is R3, and I prove it contains a(last confirmed block's MMR Hash which is block 0's)
+	Gen Proof With: [a]
+	```
+
+1. **Round 1, Sample 3**
+	```
+	                  R3
+	                /   \
+	               c     f
+	              / \   / \
+	             a   b d   e
+	Block Number 0   1 2   3
+
+	This Extended Prove: R3(proposed root which is block 3's MMR root) contains d(current sample point block's MMR Hash which is block 2's)
+	Gen Proof With: [d]
+	```
+
+1. **Round 2, Sample 2**
+	```
+	                  R3
+	                /   \
+	               c     f
+	              / \   / \
+	             a   b d   e
+	Block Number 0   1 2   3
+
+	This Extended Prove: R3(proposed root which is block 3's MMR root) contains b(current sample point block's MMR Hash which is block 1's)
+	Gen Proof With: [b]
+	```
+
+1. **Reach Last Confirmed Block, Game Over**
+
+### TODO
+
 1. **Round 0, Target 4**
 	```
 	             | Global:             | Current:

--- a/frame/bridge/relayer-game/README.md
+++ b/frame/bridge/relayer-game/README.md
@@ -27,7 +27,7 @@
 	             |   -   f
 	             |  / \
 	             | a   b
-	Block Number | 0 1
+	Block Number | 0   1
 	```
 
 1. **Round 1, Sample 3**

--- a/frame/bridge/relayer-game/src/lib.rs
+++ b/frame/bridge/relayer-game/src/lib.rs
@@ -87,11 +87,12 @@ pub trait Trait<I: Instance = DefaultInstance>: frame_system::Trait {
 decl_event! {
 	pub enum Event<T, I: Instance = DefaultInstance>
 	where
-		AccountId = AccountId<T>,
-		BlockNumber = BlockNumber<T>,
+		TcBlockNumber = TcBlockNumber<T, I>,
+		GameId = GameId<TcBlockNumber<T, I>>,
 	{
-		/// TODO
-		TODO(AccountId, BlockNumber),
+		/// A new round started.
+		/// GameId, Samples, MMR Members, MMR Last Leaf
+		NewRound(GameId, Vec<TcBlockNumber>, Vec<TcBlockNumber>, TcBlockNumber),
 	}
 }
 
@@ -114,7 +115,6 @@ decl_error! {
 	}
 }
 
-// TODO: store in relay, avoid dup codec
 decl_storage! {
 	trait Store for Module<T: Trait<I>, I: Instance = DefaultInstance> as DarwiniaRelayerGame {
 		/// All the proposals here per game
@@ -148,7 +148,7 @@ decl_storage! {
 		pub Samples
 			get(fn samples_of_game)
 			: map hasher(blake2_128_concat) TcBlockNumber<T, I>
-			=> Vec<TcBlockNumber<T, I>>;
+			=> Vec<Vec<TcBlockNumber<T, I>>>;
 
 		/// The closed rounds which had passed the challenge time at this moment
 		pub ClosedRounds
@@ -419,12 +419,24 @@ decl_module! {
 				<Headers<T, I>>::remove_prefix(game_id);
 				<Proposals<T, I>>::take(game_id);
 			};
-			let update_samples = |game_id, chain_len| {
-				<Samples<T, I>>::mutate(game_id, |samples|
-					T::RelayerGameAdjustor::update_samples(
-						T::RelayerGameAdjustor::round_from_chain_len(chain_len) + 1,
-						samples
-					)
+			let update_samples = |game_id| {
+				<Samples<T, I>>::mutate(game_id, |samples| {
+						T::RelayerGameAdjustor::update_samples(samples);
+
+						if samples.len() < 2 {
+							error!("Sample Points MISSING, \
+								Check Your Sample Strategy Implementation");
+
+							return;
+						}
+
+						Self::deposit_event(RawEvent::NewRound(
+							game_id,
+							samples.concat(),
+							samples[samples.len() - 1].clone(),
+							samples[samples.len() - 2].iter().max().unwrap().to_owned()
+						));
+					}
 				);
 			};
 
@@ -469,7 +481,7 @@ decl_module! {
 									proposals
 								);
 							} else {
-								update_samples(relay_target, last_round_proposals_chain_len as _);
+								update_samples(relay_target);
 							}
 						}
 					}
@@ -556,7 +568,7 @@ decl_module! {
 							+ T::RelayerGameAdjustor::challenge_time(0),
 						(game_id, 0)
 					);
-					<Samples<T, I>>::append(game_id, game_id);
+					<Samples<T, I>>::append(game_id, vec![game_id]);
 					<LastConfirmeds<T, I>>::insert(game_id, best_block_number);
 					<Headers<T, I>>::insert(game_id, proposed_header_hash, proposed_raw_header);
 					<Proposals<T, I>>::append(game_id, Proposal {
@@ -610,7 +622,7 @@ decl_module! {
 						// Chain's len is ALWAYS great than 1 under this match pattern; qed
 						let game_id = chain[0].number;
 
-						Self::samples_of_game(game_id)
+						Self::samples_of_game(game_id).concat()
 					};
 
 					ensure!(chain.len() == samples.len(), <Error<T, I>>::RoundMis);

--- a/frame/bridge/relayer-game/src/lib.rs
+++ b/frame/bridge/relayer-game/src/lib.rs
@@ -91,8 +91,8 @@ decl_event! {
 		GameId = GameId<TcBlockNumber<T, I>>,
 	{
 		/// A new round started.
-		/// GameId, Samples, MMR Members, MMR Last Leaf
-		NewRound(GameId, Vec<TcBlockNumber>, Vec<TcBlockNumber>, TcBlockNumber),
+		/// GameId(MMR Last Leaf), Samples, MMR Members
+		NewRound(GameId, Vec<TcBlockNumber>, Vec<TcBlockNumber>),
 	}
 }
 
@@ -434,7 +434,6 @@ decl_module! {
 							game_id,
 							samples.concat(),
 							samples[samples.len() - 1].clone(),
-							samples[samples.len() - 2].iter().max().unwrap().to_owned()
 						));
 					}
 				);

--- a/frame/bridge/relayer-game/src/lib.rs
+++ b/frame/bridge/relayer-game/src/lib.rs
@@ -493,7 +493,8 @@ decl_module! {
 		//	the bond should relate to the bytes fee
 		//	that we slash the evil relayer(s) to reward the honest relayer(s) (economic optimize)
 		// TODO: compact params? (efficency optimize)
-		// TODO: check too far from last confirmed? (efficency optimize)
+		// TODO: check too far from last confirmed? maybe we can submit some check point (efficency optimize)
+		// TODO: drop previous rounds' proof (efficency optimize)
 		#[weight = 0]
 		fn submit_proposal(origin, raw_header_thing_chain: Vec<RawHeaderThing>) {
 			let relayer = ensure_signed(origin)?;

--- a/frame/bridge/relayer-game/src/mock.rs
+++ b/frame/bridge/relayer-game/src/mock.rs
@@ -329,8 +329,8 @@ impl AdjustableRelayerGame for RelayerGameAdjustor {
 		round + 1
 	}
 
-	fn update_samples(_round: Round, samples: &mut Vec<Self::TcBlockNumber>) {
-		samples.push(samples.last().unwrap() - 1);
+	fn update_samples(samples: &mut Vec<Vec<Self::TcBlockNumber>>) {
+		samples.push(vec![samples.last().unwrap().last().unwrap() - 1]);
 	}
 
 	fn estimate_bond(_round: Round, _proposals_count: u64) -> Self::Balance {

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -152,7 +152,7 @@ pub trait AdjustableRelayerGame {
 
 	fn chain_len_from_round(round: Round) -> u64;
 
-	fn update_samples(round: Round, samples: &mut Vec<Self::TcBlockNumber>);
+	fn update_samples(samples: &mut Vec<Vec<Self::TcBlockNumber>>);
 
 	fn estimate_bond(round: Round, proposals_count: u64) -> Self::Balance;
 }


### PR DESCRIPTION
A new event added.

Once a new round started, it will deposit an event `NewRound`.

```rust
tuple NewRound(
     GameId(MMR Last Leaf): BlockNumber, // this round of which game also the last leaf, MMR::new(block_number_to_mmr_size(last_leaf))
     Samples: Vec<BlockNumber>,          // the samples need to submit for this round
     MMR Members: Vec<BlockNumber>,      // MerkleProof::gen_proof(members)
)
```