### PR TITLE
Add spec name types to adapt node-template

### DIFF
--- a/bin/node-template/runtime/darwinia_types.json
+++ b/bin/node-template/runtime/darwinia_types.json
@@ -1,4 +1,7 @@
 {
+	"__[adaptor.specname]__": {},
+	"Address": "AccountId",
+	"LookupSource": "AccountId",
 	"__[pallet.balances]__": {},
 	"BalanceInfo": null,
 	"BalanceLock": {

--- a/bin/node-template/runtime/darwinia_types.json
+++ b/bin/node-template/runtime/darwinia_types.json
@@ -1,7 +1,6 @@
 {
-	"__[adaptor.specname]__": {},
+	"__[frame.system]__": {},
 	"Address": "AccountId",
-	"LookupSource": "AccountId",
 	"__[pallet.balances]__": {},
 	"BalanceInfo": null,
 	"BalanceLock": {

--- a/bin/node-template/runtime/polkadot_compatible_types.json
+++ b/bin/node-template/runtime/polkadot_compatible_types.json
@@ -1,4 +1,7 @@
 {
+	"__[adaptor.specname]__": {},
+	"Address": "AccountId",
+	"LookupSource": "AccountId",
 	"__[pallet.balances]__": {},
 	"BalanceInfo": null,
 	"BalanceLock": {

--- a/bin/node-template/runtime/polkadot_compatible_types.json
+++ b/bin/node-template/runtime/polkadot_compatible_types.json
@@ -1,7 +1,6 @@
 {
-	"__[adaptor.specname]__": {},
+	"__[frame.system]__": {},
 	"Address": "AccountId",
-	"LookupSource": "AccountId",
 	"__[pallet.balances]__": {},
 	"BalanceInfo": null,
 	"BalanceLock": {


### PR DESCRIPTION
## Desc

Javascript program appears `Could not convert` errors because we don't have `{"Address": "AccountId","LookupSource": "AccountId"}` in our `types.json`, ref to the FAQ [the-node-returns-a-could-not-convert-error-on-send][0]

[0]: https://polkadot.js.org/api/start/FAQ.html#the-node-returns-a-could-not-convert-error-on-send