### PR TITLE
fix: always return some

### DIFF
--- a/frame/header-mmr/src/lib.rs
+++ b/frame/header-mmr/src/lib.rs
@@ -94,7 +94,7 @@ pub trait Trait: frame_system::Trait {}
 decl_storage! {
 	trait Store for Module<T: Trait> as DarwiniaHeaderMMR {
 		/// MMR struct of the previous blocks, from first(genesis) to parent hash.
-		pub MMRNodeList get(fn mmr_node_list): map hasher(identity) u64 => T::Hash;
+		pub MMRNodeList get(fn mmr_node_list): map hasher(identity) u64 => Option<T::Hash>;
 
 		/// The MMR size and length of the mmr node list
 		pub MMRCounter get(fn mmr_counter): u64;
@@ -200,7 +200,7 @@ impl<T> Default for ModuleMMRStore<T> {
 }
 impl<T: Trait> MMRStore<T::Hash> for ModuleMMRStore<T> {
 	fn get_elem(&self, pos: u64) -> Result<Option<T::Hash>> {
-		Ok(Some(<Module<T>>::mmr_node_list(pos)))
+		Ok(<Module<T>>::mmr_node_list(pos))
 	}
 
 	fn append(&mut self, pos: u64, elems: Vec<T::Hash>) -> Result<()> {

--- a/frame/header-mmr/src/tests.rs
+++ b/frame/header-mmr/src/tests.rs
@@ -57,7 +57,7 @@ fn test_insert_header() {
 
 		let pos = 19;
 		assert_eq!(pos, leaf_index_to_pos(h1));
-		assert_eq!(prove_elem, HeaderMMR::mmr_node_list(pos));
+		assert_eq!(prove_elem, HeaderMMR::mmr_node_list(pos).unwrap());
 
 		let parent_mmr_root = HeaderMMR::_find_parent_mmr_root(headers[h2 as usize - 1].clone())
 			.expect("Header mmr get failed");


### PR DESCRIPTION
```rust
// T::Hash impl Default
pub MMRNodeList get(fn mmr_node_list): map hasher(identity) u64 => T::Hash;

fn get_elem(&self, pos: u64) -> Result<Option<T::Hash>> {
    Ok(Some(<Module<T>>::mmr_node_list(pos)))
}
```

This will always return a valid hash. Get mmr root will never fail. Even the size is wrong.