### PR TITLE
Some chores about dvm 

### DIFF
--- a/bin/node/runtime/pangolin/src/dvm.rs
+++ b/bin/node/runtime/pangolin/src/dvm.rs
@@ -3,7 +3,6 @@ use frame_support::{traits::FindAuthor, ConsensusEngineId};
 use sp_core::{crypto::Public, H160, U256};
 // --- darwinia ---
 use crate::*;
-use darwinia_evm::ConcatAddressMapping;
 use dvm_ethereum::{Config, IntermediateStateRoot};
 
 pub struct EthereumFindAuthor<F>(sp_std::marker::PhantomData<F>);
@@ -27,6 +26,5 @@ impl Config for Runtime {
 	type FindAuthor = EthereumFindAuthor<Babe>;
 	type StateRoot = IntermediateStateRoot;
 	type BlockGasLimit = BlockGasLimit;
-	type AddressMapping = ConcatAddressMapping;
 	type RingCurrency = Ring;
 }

--- a/frame/dvm/src/lib.rs
+++ b/frame/dvm/src/lib.rs
@@ -377,12 +377,6 @@ impl<T: Config> Module<T> {
 		};
 		let mut block = ethereum::Block::new(partial_header, transactions.clone(), ommers);
 		block.header.state_root = T::StateRoot::get();
-		let mut transaction_hashes = Vec::new();
-
-		for t in &transactions {
-			let transaction_hash = H256::from_slice(Keccak256::digest(&rlp::encode(t)).as_slice());
-			transaction_hashes.push(transaction_hash);
-		}
 
 		CurrentBlock::put(block.clone());
 		CurrentReceipts::put(receipts.clone());

--- a/frame/dvm/src/lib.rs
+++ b/frame/dvm/src/lib.rs
@@ -23,7 +23,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 // --- darwinia ---
-use darwinia_evm::{AccountBasicMapping, AddressMapping, FeeCalculator, GasWeightMapping, Runner};
+use darwinia_evm::{AccountBasicMapping, FeeCalculator, GasWeightMapping, Runner};
 use dp_consensus::{PostLog, PreLog, FRONTIER_ENGINE_ID};
 use dp_evm::CallOrCreateInfo;
 use dp_storage::PALLET_ETHEREUM_SCHEMA;
@@ -79,7 +79,6 @@ impl Default for EthereumStorageSchema {
 }
 
 /// A type alias for the balance type from this pallet's point of view.
-pub type BalanceOf<T> = <T as darwinia_balances::Config>::Balance;
 type RingInstance = darwinia_balances::Instance0;
 
 pub struct IntermediateStateRoot;
@@ -106,8 +105,6 @@ pub trait Config:
 	type StateRoot: Get<H256>;
 	/// The block gas limit. Can be a simple constant, or an adjustment algorithm in another pallet.
 	type BlockGasLimit: Get<U256>;
-	// How evm address convert to darwinia address
-	type AddressMapping: AddressMapping<Self::AccountId>;
 	// Balance module
 	type RingCurrency: Currency<Self::AccountId>;
 }

--- a/frame/dvm/src/mock.rs
+++ b/frame/dvm/src/mock.rs
@@ -176,7 +176,6 @@ impl Config for Test {
 	type FindAuthor = EthereumFindAuthor;
 	type StateRoot = IntermediateStateRoot;
 	type BlockGasLimit = BlockGasLimit;
-	type AddressMapping = HashedAddressMapping;
 	type RingCurrency = Ring;
 }
 


### PR DESCRIPTION
1. In the dvm pallet, we can directly use the evm pallet `AddressMapping` type.
2. `transaction_hashes` related operations have been moved to the `Hashes::from_block()`