### PR TITLE
Test dvm migration use try-runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2245,6 +2245,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "libsecp256k1",
+ "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "rlp",

--- a/bin/node/runtime/pangolin/Cargo.toml
+++ b/bin/node/runtime/pangolin/Cargo.toml
@@ -178,4 +178,5 @@ try-runtime = [
 	"frame-try-runtime",
 	"darwinia-crab-issuing/try-runtime",
 	"darwinia-staking/try-runtime",
+	"dvm-ethereum/try-runtime",
 ]

--- a/bin/node/runtime/pangolin/src/lib.rs
+++ b/bin/node/runtime/pangolin/src/lib.rs
@@ -798,9 +798,7 @@ pub struct CustomOnRuntimeUpgrade;
 impl OnRuntimeUpgrade for CustomOnRuntimeUpgrade {
 	#[cfg(feature = "try-runtime")]
 	fn pre_upgrade() -> Result<(), &'static str> {
-		darwinia_crab_issuing::migration::try_runtime::pre_migrate::<Runtime>()?;
-		darwinia_staking::migrations::v6::pre_migrate::<Runtime>()?;
-		dvm_ethereum::migration::try_runtime::pre_migrate::<Runtime>()
+		Ok(())
 	}
 
 	fn on_runtime_upgrade() -> Weight {

--- a/bin/node/runtime/pangolin/src/lib.rs
+++ b/bin/node/runtime/pangolin/src/lib.rs
@@ -799,7 +799,8 @@ impl OnRuntimeUpgrade for CustomOnRuntimeUpgrade {
 	#[cfg(feature = "try-runtime")]
 	fn pre_upgrade() -> Result<(), &'static str> {
 		darwinia_crab_issuing::migration::try_runtime::pre_migrate::<Runtime>()?;
-		darwinia_staking::migrations::v6::pre_migrate::<Runtime>()
+		darwinia_staking::migrations::v6::pre_migrate::<Runtime>()?;
+		dvm_ethereum::migration::try_runtime::pre_migrate::<Runtime>()
 	}
 
 	fn on_runtime_upgrade() -> Weight {

--- a/frame/dvm/Cargo.toml
+++ b/frame/dvm/Cargo.toml
@@ -17,6 +17,7 @@ ethereum       = { version = "0.7.1", default-features = false, features = ["wit
 ethereum-types = { version = "0.11.0", default-features = false }
 evm            = { version = "0.25.0", default-features = false, features = ["with-codec"] }
 libsecp256k1   = { version = "0.3.5", default-features = false }
+log            = { version = "0.4.14", optional = true}
 rlp            = { version = "0.5.0", default-features = false }
 serde          = { version = "1.0.125", optional = true, default-features = false }
 sha3           = { version = "0.9.1", default-features = false }
@@ -76,4 +77,9 @@ substrate-std = [
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-std/std",
+]
+
+try-runtime = [
+	"log",
+	"frame-support/try-runtime",
 ]

--- a/frame/dvm/Cargo.toml
+++ b/frame/dvm/Cargo.toml
@@ -17,7 +17,7 @@ ethereum       = { version = "0.7.1", default-features = false, features = ["wit
 ethereum-types = { version = "0.11.0", default-features = false }
 evm            = { version = "0.25.0", default-features = false, features = ["with-codec"] }
 libsecp256k1   = { version = "0.3.5", default-features = false }
-log            = { version = "0.4.14", optional = true}
+log            = { version = "0.4.14", optional = true }
 rlp            = { version = "0.5.0", default-features = false }
 serde          = { version = "1.0.125", optional = true, default-features = false }
 sha3           = { version = "0.9.1", default-features = false }

--- a/frame/dvm/src/lib.rs
+++ b/frame/dvm/src/lib.rs
@@ -27,8 +27,6 @@ use darwinia_evm::{AccountBasic, FeeCalculator, GasWeightMapping, Runner};
 use darwinia_support::evm::INTERNAL_CALLER;
 use dp_consensus::{PostLog, PreLog, FRONTIER_ENGINE_ID};
 use dp_evm::CallOrCreateInfo;
-#[cfg(feature = "std")]
-use dp_storage::PALLET_ETHEREUM_SCHEMA;
 pub use dvm_rpc_runtime_api::{DVMTransaction, TransactionStatus};
 // --- substrate ---
 use frame_support::ensure;
@@ -135,6 +133,7 @@ decl_storage! {
 			<Module<T>>::store_block(false);
 
 			// Initialize the storage schema at the well known key.
+			#[cfg(not(feature = "try-runtime"))]
 			frame_support::storage::unhashed::put::<EthereumStorageSchema>(&PALLET_ETHEREUM_SCHEMA, &EthereumStorageSchema::V1);
 		});
 	}

--- a/frame/dvm/src/lib.rs
+++ b/frame/dvm/src/lib.rs
@@ -27,6 +27,7 @@ use darwinia_evm::{AccountBasic, FeeCalculator, GasWeightMapping, Runner};
 use darwinia_support::evm::INTERNAL_CALLER;
 use dp_consensus::{PostLog, PreLog, FRONTIER_ENGINE_ID};
 use dp_evm::CallOrCreateInfo;
+use dp_storage::PALLET_ETHEREUM_SCHEMA;
 pub use dvm_rpc_runtime_api::{DVMTransaction, TransactionStatus};
 // --- substrate ---
 use frame_support::ensure;

--- a/frame/dvm/src/lib.rs
+++ b/frame/dvm/src/lib.rs
@@ -41,12 +41,11 @@ use ethereum_types::{Bloom, BloomInput, H160, H256, H64, U256};
 use evm::ExitReason;
 use sha3::{Digest, Keccak256};
 // --- substrate ---
-#[cfg(any(feature = "std", feature = "try-runtime"))]
-use frame_support::storage::unhashed;
 use frame_support::{
 	decl_error, decl_event, decl_module, decl_storage,
 	dispatch::DispatchResultWithPostInfo,
 	ensure,
+	storage::unhashed,
 	traits::FindAuthor,
 	traits::{Currency, Get},
 	weights::Weight,
@@ -66,7 +65,6 @@ use darwinia_evm::{AccountBasic, FeeCalculator, GasWeightMapping, Runner};
 use darwinia_support::evm::INTERNAL_CALLER;
 use dp_consensus::{PostLog, PreLog, FRONTIER_ENGINE_ID};
 use dp_evm::CallOrCreateInfo;
-#[cfg(any(feature = "std", feature = "try-runtime"))]
 use dp_storage::PALLET_ETHEREUM_SCHEMA;
 
 /// A type alias for the balance type from this pallet's point of view.


### PR DESCRIPTION

```sh
$ ./target/release/drml try-runtime live http://localhost:9933
2021-04-20 13:57:43 `pallet_timestamp::UnixTime::now` is called at genesis, invalid value returned: 0    
2021-04-20 13:57:43 [#0] 🗳  Finalized election round with compute ElectionCompute::OnChain.    
2021-04-20 13:57:43 [0] 💸 new validator set of size 1 has been processed for era 1    
2021-04-20 13:57:43 [darwinia-claims] Genesis Claims List is Set to EMPTY    
2021-04-20 13:57:43 initializing remote client to "http://localhost:9933"    
2021-04-20 13:57:43 scraping keypairs from remote node http://localhost:9933 @ 0x9de6f0e79a771f6fdbae5dadd58aef9f37abd8c225c9fcc072e5bf66a907f320    
2021-04-20 13:57:43 downloading data for all modules.    
2021-04-20 13:57:43 extending externalities with 1 manually injected keys    
2021-04-20 13:57:43 injecting a total of 692 keys    
2021-04-20 13:57:43 Schema migration successfully!    
2021-04-20 13:57:43 ⚠️ System declares internal migrations (which *might* execute), setting storage version to PalletVersion { major: 3, minor: 0, patch: 0 } 
```