### PR TITLE
Capture runner call error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1608,6 +1608,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex",
+ "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "ripemd160",
@@ -2648,9 +2649,9 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca5faf057445ce5c9d4329e382b2ce7ca38550ef3b73a5348362d5f24e0c7fe3"
+checksum = "77b705829d1e87f762c2df6da140b26af5839e1033aa84aa5f56bb688e4e1bdb"
 dependencies = [
  "instant",
 ]

--- a/frame/evm/precompile/contracts/kton/Cargo.toml
+++ b/frame/evm/precompile/contracts/kton/Cargo.toml
@@ -16,6 +16,7 @@ codec          = { package = "parity-scale-codec", version = "2.0.1", default-fe
 ethereum-types = { version = "0.11.0", default-features = false }
 evm            = { version = "0.25.0", default-features = false, features = ["with-codec"] }
 hex            = { version = "0.4.3", default-features = false }
+log             = { version = "0.4.14" }
 ripemd160      = { version = "0.9.1", default-features = false }
 sha3           = { version = "0.9.1", default-features = false }
 # darwinia

--- a/frame/evm/precompile/contracts/kton/Cargo.toml
+++ b/frame/evm/precompile/contracts/kton/Cargo.toml
@@ -16,7 +16,7 @@ codec          = { package = "parity-scale-codec", version = "2.0.1", default-fe
 ethereum-types = { version = "0.11.0", default-features = false }
 evm            = { version = "0.25.0", default-features = false, features = ["with-codec"] }
 hex            = { version = "0.4.3", default-features = false }
-log             = { version = "0.4.14" }
+log            = { version = "0.4.14" }
 ripemd160      = { version = "0.9.1", default-features = false }
 sha3           = { version = "0.9.1", default-features = false }
 # darwinia

--- a/frame/evm/precompile/contracts/kton/src/lib.rs
+++ b/frame/evm/precompile/contracts/kton/src/lib.rs
@@ -23,7 +23,7 @@ mod util;
 use codec::Decode;
 use core::str::FromStr;
 use ethabi::{Function, Param, ParamType, Token};
-use evm::{Context, ExitError, ExitSucceed};
+use evm::{Context, ExitError, ExitReason, ExitSucceed};
 use frame_support::{ensure, traits::Currency};
 use sha3::Digest;
 use sp_core::{H160, U256};
@@ -96,7 +96,7 @@ impl<T: Config + dvm_ethereum::Config> Precompile for Kton<T> {
 				// Call WKTON wrapped contract deposit
 				let precompile_address = H160::from_str(KTON_PRECOMPILE).unwrap_or_default();
 				let raw_input = make_call_data(context.caller, call_data.value)?;
-				T::Runner::call(
+				if let Ok(call_res) = T::Runner::call(
 					precompile_address,
 					call_data.wkton_address,
 					raw_input.to_vec(),
@@ -105,8 +105,14 @@ impl<T: Config + dvm_ethereum::Config> Precompile for Kton<T> {
 					None,
 					None,
 					T::config(),
-				)
-				.map_err(|_| ExitError::Other("Call in Kton precompile failed".into()))?;
+				) {
+					match call_res.exit_reason {
+						ExitReason::Succeed(_) => {
+							log::debug!("Transfer and call execute success.");
+						}
+						_ => return Err(ExitError::Other("Call in Kton precompile failed".into())),
+					}
+				}
 
 				Ok((ExitSucceed::Returned, vec![], 20000))
 			}

--- a/frame/evm/precompile/contracts/kton/src/util.rs
+++ b/frame/evm/precompile/contracts/kton/src/util.rs
@@ -1,13 +1,11 @@
 pub fn e2s_address(eth_address: ethereum_types::H160) -> sp_core::H160 {
 	let eth_address_bytes = eth_address.to_fixed_bytes();
-	let sp_address = sp_core::H160::from_slice(&eth_address_bytes);
-	sp_address
+	sp_core::H160::from_slice(&eth_address_bytes)
 }
 
 pub fn s2e_address(sp_address: sp_core::H160) -> ethereum_types::H160 {
 	let sp_address_bytes = sp_address.to_fixed_bytes();
-	let eth_address = ethereum_types::H160::from_slice(&sp_address_bytes);
-	eth_address
+	ethereum_types::H160::from_slice(&sp_address_bytes)
 }
 
 pub fn e2s_u256(eth_value: ethereum_types::U256) -> sp_core::U256 {


### PR DESCRIPTION
The runner call function always returns `Ok(...)` even an inner execution error happened.

We should capture the `exit_reason` contained in the call result and make a decision to commit or discard state change.