### PR TITLE
Remove Event `TargetMinGasPriceSet`

### DIFF
--- a/bin/node/runtime/pangolin/src/lib.rs
+++ b/bin/node/runtime/pangolin/src/lib.rs
@@ -270,7 +270,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: sp_runtime::create_runtime_str!("Pangolin"),
 	authoring_version: 1,
 	// crate version ~2.4.0 := >=2.4.0, <2.5.0
-	spec_version: 2401,
+	spec_version: 2402,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/frame/democracy/src/lib.rs
+++ b/frame/democracy/src/lib.rs
@@ -157,7 +157,7 @@ use frame_support::{
 use frame_system::{self as system, ensure_root, ensure_signed};
 use sp_runtime::{
 	traits::{Bounded, Dispatchable, Hash, Saturating, Zero},
-	DispatchError, DispatchResult, RuntimeDebug, ArithmeticError
+	ArithmeticError, DispatchError, DispatchResult, RuntimeDebug,
 };
 use sp_std::prelude::*;
 // --- darwinia ---

--- a/frame/dvm-dynamic-fee/src/lib.rs
+++ b/frame/dvm-dynamic-fee/src/lib.rs
@@ -77,9 +77,7 @@ decl_module! {
 			target: U256,
 		) {
 			ensure_none(origin)?;
-
 			TargetMinGasPrice::set(Some(target));
-			Self::deposit_event(Event::TargetMinGasPriceSet(target));
 		}
 	}
 }

--- a/frame/dvm-dynamic-fee/src/lib.rs
+++ b/frame/dvm-dynamic-fee/src/lib.rs
@@ -61,7 +61,7 @@ decl_module! {
 
 		fn on_initialize(_block_number: T::BlockNumber) -> Weight {
 			TargetMinGasPrice::kill();
-			0
+			T::DbWeight::get().writes(1)
 		}
 
 		fn on_finalize(_block_number: T::BlockNumber) {
@@ -75,7 +75,7 @@ decl_module! {
 			}
 		}
 
-		#[weight = 0]
+		#[weight = T::DbWeight::get().writes(1)]
 		fn note_min_gas_price_target(
 			origin,
 			target: U256,

--- a/frame/dvm-dynamic-fee/src/lib.rs
+++ b/frame/dvm-dynamic-fee/src/lib.rs
@@ -23,6 +23,7 @@ use frame_support::{
 	decl_event, decl_module, decl_storage,
 	inherent::{InherentData, InherentIdentifier, IsFatalError, ProvideInherent},
 	traits::Get,
+	weights::Weight,
 };
 use frame_system::ensure_none;
 use sp_core::U256;
@@ -58,6 +59,11 @@ decl_module! {
 	pub struct Module<T: Config> for enum Call where origin: T::Origin {
 		fn deposit_event() = default;
 
+		fn on_initialize(_block_number: T::BlockNumber) -> Weight {
+			TargetMinGasPrice::kill();
+			0
+		}
+
 		fn on_finalize(_block_number: T::BlockNumber) {
 			if let Some(target) = TargetMinGasPrice::get() {
 				let bound = MinGasPrice::get() / T::MinGasPriceBoundDivisor::get() + U256::one();
@@ -67,8 +73,6 @@ decl_module! {
 
 				MinGasPrice::set(min(upper_limit, max(lower_limit, target)));
 			}
-
-			TargetMinGasPrice::kill();
 		}
 
 		#[weight = 0]


### PR DESCRIPTION
1. There is no need to output the target gas price event for each block.
2. Move `kill()` into the `on_initialize`, then you can view`TargetMinGasPrice` value in explorer.

![image](https://user-images.githubusercontent.com/11801722/119352239-02bd9680-bcd4-11eb-828b-6d7eb0e31631.png)
