### PR TITLE
Correct Collective Genesis

### DIFF
--- a/bin/node/cli/src/chain_spec.rs
+++ b/bin/node/cli/src/chain_spec.rs
@@ -511,16 +511,19 @@ fn pangolin_development_genesis() -> pangolin_runtime::GenesisConfig {
 		pallet_im_online: Default::default(),
 		pallet_authority_discovery: Default::default(),
 		darwinia_democracy: Default::default(),
-		pallet_collective_Instance1: pangolin_runtime::CouncilConfig {
-			phantom: PhantomData::<pangolin_runtime::CouncilCollective>,
+		pallet_collective_Instance1: Default::default(),
+		pallet_collective_Instance2: Default::default(),
+		darwinia_elections_phragmen: pangolin_runtime::PhragmenElectionConfig {
+			members: collective_members
+				.iter()
+				.cloned()
+				.map(|a| (a, A_FEW_COINS))
+				.collect(),
+		},
+		pallet_membership_Instance1: pangolin_runtime::TechnicalMembershipConfig {
+			phantom: PhantomData::<pangolin_runtime::TechnicalMembershipInstance>,
 			members: collective_members.clone(),
 		},
-		pallet_collective_Instance2: pangolin_runtime::TechnicalCommitteeConfig {
-			phantom: PhantomData::<pangolin_runtime::TechnicalCollective>,
-			members: collective_members
-		},
-		darwinia_elections_phragmen: Default::default(),
-		pallet_membership_Instance1: Default::default(),
 		darwinia_claims: pangolin_runtime::ClaimsConfig {
 			claims_list: ClaimsList::from_file(
 				"bin/res/claims-list.json",

--- a/bin/node/runtime/pangolin/src/pallets/membership.rs
+++ b/bin/node/runtime/pangolin/src/pallets/membership.rs
@@ -1,6 +1,8 @@
+pub use pallet_membership::Instance1 as TechnicalMembershipInstance;
+
 // --- substrate ---
 use frame_support::traits::ChangeMembers;
-use pallet_membership::{weights::SubstrateWeight, Config, Instance1};
+use pallet_membership::{weights::SubstrateWeight, Config};
 // --- darwinia ---
 use crate::*;
 
@@ -16,7 +18,7 @@ impl ChangeMembers<AccountId> for MembershipChangedGroup {
 	}
 }
 
-impl Config<Instance1> for Runtime {
+impl Config<TechnicalMembershipInstance> for Runtime {
 	type Event = Event;
 	type AddOrigin = EnsureRootOrMoreThanHalfCouncil;
 	type RemoveOrigin = EnsureRootOrMoreThanHalfCouncil;


### PR DESCRIPTION
We should initialize the collective members from these 2 pallets
1. Membership [Genesis](https://github.com/paritytech/substrate/blob/master/frame/membership/src/lib.rs#L88) <-> [Runtime Configuration](https://github.com/darwinia-network/darwinia-common/blob/master/bin/node/runtime/pangolin/src/pallets/membership.rs#L26)
2. Elections phragmen [Genesis](https://github.com/paritytech/substrate/blob/master/frame/elections-phragmen/src/lib.rs#L699) <-> [Runtime Configuration](https://github.com/darwinia-network/darwinia-common/blob/master/bin/node/runtime/pangolin/src/pallets/elections_phragmen.rs#L27)