### PR TITLE
Tag Thirdparty Libraries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2651,7 +2651,7 @@ dependencies = [
 [[package]]
 name = "ethabi"
 version = "13.0.0"
-source = "git+https://github.com/darwinia-network/ethabi.git?branch=xavier-no-std#baacf174d5c2f12122c4ee3fe31506fb52069983"
+source = "git+https://github.com/darwinia-network/ethabi.git?tag=v13.0.0-no-std#baacf174d5c2f12122c4ee3fe31506fb52069983"
 dependencies = [
  "anyhow",
  "ethereum-types",
@@ -2666,11 +2666,10 @@ dependencies = [
 [[package]]
 name = "ethash"
 version = "0.4.0"
-source = "git+https://github.com/darwinia-network/rust-ethash#9014d7649c19800f3b37944a23dd499d207cf881"
+source = "git+https://github.com/darwinia-network/rust-ethash?tag=v0.4.0#e5d6d4c490ac710d793db4f8c1c1bdbb2bfbb164"
 dependencies = [
  "byteorder",
  "ethereum-types",
- "primitive-types",
  "rlp",
  "sha3 0.9.1",
 ]

--- a/frame/bridge/ethereum/backing/Cargo.toml
+++ b/frame/bridge/ethereum/backing/Cargo.toml
@@ -19,7 +19,7 @@ serde_json  = { version = "1.0.64", optional = true }
 # darwinia
 darwinia-relay-primitives = { default-features = false, path = "../../../../primitives/relay" }
 darwinia-support          = { default-features = false, path = "../../../support" }
-ethabi                    = { default-features = false, git = "https://github.com/darwinia-network/ethabi", branch = "xavier-no-std" }
+ethabi                    = { default-features = false, git = "https://github.com/darwinia-network/ethabi", tag = "v13.0.0-no-std" }
 ethereum-primitives       = { default-features = false, path = "../../../../primitives/ethereum-primitives" }
 # substrate
 frame-support = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "main" }
@@ -55,12 +55,12 @@ std = [
 	"substrate-std",
 ]
 
-crates-std    = [
+crates-std = [
 	"codec/std",
 	"serde",
 	"serde_json",
 ]
-darwinia-std  = [
+darwinia-std = [
 	"darwinia-relay-primitives/std",
 	"darwinia-support/std",
 	"ethabi/std",

--- a/frame/bridge/ethereum/issuing/contract/Cargo.toml
+++ b/frame/bridge/ethereum/issuing/contract/Cargo.toml
@@ -13,7 +13,7 @@ version     = "2.5.0"
 # crates
 ethereum-types = { default-features = false, version = "0.11.0" }
 # github
-ethabi = { default-features = false, git = "https://github.com/darwinia-network/ethabi", branch = "xavier-no-std" }
+ethabi = { default-features = false, git = "https://github.com/darwinia-network/ethabi", tag = "v13.0.0-no-std" }
 
 [features]
 default = ["std"]

--- a/frame/dvm/Cargo.toml
+++ b/frame/dvm/Cargo.toml
@@ -39,7 +39,7 @@ sp-std           = { default-features = false, git = "https://github.com/darwini
 [dev-dependencies]
 # crates.io
 array-bytes = { version = "1.3.3" }
-ethabi      = { git = "https://github.com/darwinia-network/ethabi", branch = "xavier-no-std" }
+ethabi      = { git = "https://github.com/darwinia-network/ethabi", tag = "v13.0.0-no-std" }
 # darwinia
 darwinia-balances                = { path = "../balances" }
 darwinia-evm-precompile-simple   = { path = "../evm/precompile/contracts/simple" }
@@ -54,7 +54,7 @@ std = [
 	"substrate-std",
 ]
 
-crates-std    = [
+crates-std = [
 	"codec/std",
 	"ethereum/std",
 	"ethereum-types/std",
@@ -64,7 +64,7 @@ crates-std    = [
 	"serde",
 	"sha3/std",
 ]
-darwinia-std  = [
+darwinia-std = [
 	"darwinia-evm/std",
 	"darwinia-support/std",
 	"dp-evm/std",

--- a/frame/evm/precompile/contracts/transfer/Cargo.toml
+++ b/frame/evm/precompile/contracts/transfer/Cargo.toml
@@ -13,9 +13,9 @@ version     = "2.5.0"
 # crates
 array-bytes    = { version = "1.3.3" }
 codec          = { package = "parity-scale-codec", version = "2.1.1", default-features = false }
-ethabi         = { git = "https://github.com/darwinia-network/ethabi", branch = "xavier-no-std", default-features = false }
-evm            = { version = "0.25.0", features = ["with-codec"], default-features = false }
+ethabi         = { default-features = false, git = "https://github.com/darwinia-network/ethabi", tag = "v13.0.0-no-std" }
 ethereum-types = { version = "0.11.0", default-features = false }
+evm            = { version = "0.25.0", default-features = false, features = ["with-codec"] }
 log            = { version = "0.4.14" }
 ripemd160      = { version = "0.9.1", default-features = false }
 sha3           = { version = "0.9.1", default-features = false }

--- a/frame/support/Cargo.toml
+++ b/frame/support/Cargo.toml
@@ -16,7 +16,7 @@ codec                 = { package = "parity-scale-codec", version = "2.1.1", def
 impl-trait-for-tuples = { version = "0.2.1" }
 num-traits            = { version = "0.2.14", default-features = false }
 # darwinia
-ethabi              = { default-features = false, git = "https://github.com/darwinia-network/ethabi.git", branch = "xavier-no-std" }
+ethabi              = { default-features = false, git = "https://github.com/darwinia-network/ethabi.git", tag = "v13.0.0-no-std" }
 ethereum-primitives = { default-features = false, path = "../../primitives/ethereum-primitives" }
 # paritytech
 bp-runtime    = { default-features = false, git = "https://github.com/darwinia-network/parity-bridges-common", branch = "main" }

--- a/primitives/contract/Cargo.toml
+++ b/primitives/contract/Cargo.toml
@@ -13,7 +13,7 @@ version     = "2.5.0"
 # crates
 ethereum-types = { default-features = false, version = "0.11.0" }
 # darwinia
-ethabi = { default-features = false, git = "https://github.com/darwinia-network/ethabi.git", branch = "xavier-no-std" }
+ethabi = { default-features = false, git = "https://github.com/darwinia-network/ethabi.git", tag = "v13.0.0-no-std" }
 # paritytech
 sp-std = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "main" }
 

--- a/primitives/ethereum-primitives/Cargo.toml
+++ b/primitives/ethereum-primitives/Cargo.toml
@@ -24,7 +24,7 @@ rlp             = { version = "0.5.0", default-features = false }
 rlp-derive      = { version = "0.1.0" }
 serde           = { version = "1.0.126", optional = true, features = ["derive"] }
 # darwinia
-ethash               = { default-features = false, git = "https://github.com/darwinia-network/rust-ethash" }
+ethash               = { default-features = false, git = "https://github.com/darwinia-network/rust-ethash", tag = "v0.4.0" }
 merkle-patricia-trie = { default-features = false, path = "../merkle-patricia-trie" }
 # substrate
 sp-io      = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "main" }
@@ -49,7 +49,7 @@ std = [
 	"substrate-std",
 ]
 
-crates-std    = [
+crates-std = [
 	"codec/std",
 	"ethbloom/std",
 	"ethereum-types/std",
@@ -62,7 +62,7 @@ crates-std    = [
 	"rlp/std",
 	"serde",
 ]
-darwinia-std  = [
+darwinia-std = [
 	"ethash/std",
 	"merkle-patricia-trie/std",
 ]


### PR DESCRIPTION
Anchor the libraries to a particular tag. Avoid getting updated accidentally while running `cargo update` globally.