### PR TITLE
Remove Unecessary Feature Control for Pallets

### DIFF
--- a/frame/bridge/ethereum/backing/Cargo.toml
+++ b/frame/bridge/ethereum/backing/Cargo.toml
@@ -33,7 +33,7 @@ sp-std        = { default-features = false, git = "https://github.com/darwinia-n
 rlp = { version = "0.5.0" }
 # darwinia-network
 darwinia-balances         = { path = "../../../../frame/balances" }
-darwinia-ethereum-relay   = { features = ["full-serde"], path = "../relay" }
+darwinia-ethereum-relay   = { path = "../relay" }
 darwinia-relay-primitives = { path = "../../../../primitives/relay" }
 darwinia-relayer-game     = { path = "../../relayer-game" }
 darwinia-staking          = { path = "../../../../frame/staking" }

--- a/frame/bridge/ethereum/relay/Cargo.toml
+++ b/frame/bridge/ethereum/relay/Cargo.toml
@@ -65,7 +65,3 @@ std = [
 	"sp-runtime/std",
 	"sp-std/std",
 ]
-
-full-serde = [
-	"ethereum-primitives/full-serde",
-]

--- a/frame/bridge/ethereum/relay/src/lib.rs
+++ b/frame/bridge/ethereum/relay/src/lib.rs
@@ -56,7 +56,7 @@ pub mod migration {
 		dbg!(parcel.encode());
 	}
 
-	#[cfg(feature = "full-serde")]
+	#[cfg(feature = "std")]
 	pub fn assert_encoded_eq(raw: impl AsRef<str>, encoded: impl AsRef<[u8]>) {
 		let from_json = serde_json::from_str::<EthereumRelayHeaderParcel>(raw.as_ref()).unwrap();
 		let from_codec = decode(encoded);
@@ -1016,7 +1016,7 @@ impl<T: Config> EthereumReceiptT<AccountId<T>, RingBalance<T>> for Module<T> {
 	}
 }
 
-#[cfg_attr(any(feature = "full-serde", test), derive(serde::Deserialize))]
+#[cfg_attr(any(feature = "std", test), derive(serde::Deserialize))]
 #[derive(Clone, PartialEq, Encode, Decode, RuntimeDebug)]
 pub struct EthereumRelayHeaderParcel {
 	pub header: EthereumHeader,
@@ -1030,14 +1030,14 @@ impl RelayHeaderParcelInfo for EthereumRelayHeaderParcel {
 	}
 }
 
-#[cfg_attr(any(feature = "full-serde", test), derive(serde::Deserialize))]
+#[cfg_attr(any(feature = "std", test), derive(serde::Deserialize))]
 #[derive(Clone, PartialEq, Encode, Decode, RuntimeDebug)]
 pub struct EthereumRelayProofs {
 	pub ethash_proof: Vec<EthashProof>,
 	pub mmr_proof: Vec<H256>,
 }
 
-#[cfg_attr(any(feature = "full-serde", test), derive(serde::Deserialize))]
+#[cfg_attr(any(feature = "std", test), derive(serde::Deserialize))]
 #[derive(Clone, Default, PartialEq, Encode, Decode, RuntimeDebug)]
 pub struct MMRProof {
 	pub member_leaf_index: u64,


### PR DESCRIPTION
Serde should always enable under STD ENV. Because `GenesisBuilder` is always under STD ENV.