### PR TITLE
Add Rustdoc to CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build rust docs
+        run: cargo doc --all --no-deps --release
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+      - name: Install vercel
+        run: npm i -g vercel
+      - name: Deploy rust docs
+        run: |
+          mv vercel.json target/doc
+          mv target/doc target/${GITHUB_REPOSITORY#*/}
+          cd target/${GITHUB_REPOSITORY#*/}
+          vercel --token ${{ secrets.VERCEL_TOKEN }} --scope itering link --confirm
+          vercel --token ${{ secrets.VERCEL_TOKEN }} --scope itering deploy --prod
+

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "redirects": [
+    { "source": "/", "destination": "/drml" }
+  ]
+}


### PR DESCRIPTION
When a new tag is created (Must start with `v`). will build and deploy rust docs. when the deployment is successful, the domain darwinia-common.vercel.app can be accessed rust docs