### PR TITLE
Fix Polkadot JS Balance Lock Relateds

### DIFF
--- a/node/runtime/pangolin/polkadot-compatible-types.json
+++ b/node/runtime/pangolin/polkadot-compatible-types.json
@@ -4,9 +4,7 @@
 	"BalanceLock": {
 		"id": "LockIdentifier",
 		"lock_for": "LockFor",
-		"lock_reasons": "LockReasons",
-		"amount": "Balance",
-		"reasons": "Reasons"
+		"lock_reasons": "LockReasons"
 	},
 	"LockFor": {
 		"_enum": {
@@ -36,9 +34,7 @@
 		"free": "Balance",
 		"reserved": "Balance",
 		"free_kton": "Balance",
-		"reserved_kton": "Balance",
-		"misc_frozen": "Balance",
-		"fee_frozen": "Balance"
+		"reserved_kton": "Balance"
 	},
 	"__[pallet.staking]__": {},
 	"RingBalance": "Balance",
@@ -78,8 +74,7 @@
 		"who": "AccountId",
 		"ring_balance": "Compact<Balance>",
 		"kton_balance": "Compact<Balance>",
-		"power": "Power",
-		"value": "Compact<Balance>"
+		"power": "Power"
 	},
 	"RKT": {
 		"r": "Balance",


### PR DESCRIPTION
```
{
	"IndividualExposure": {
		"who": "AccountId",
		"ring_balance": "Compact<Balance>",
		"kton_balance": "Compact<Balance>",
		"power": "Power"
	},
	"AccountData": {
		"free": "Balance",
		"reserved": "Balance",
		"free_kton": "Balance",
		"reserved_kton": "Balance"
	},
	"BalanceLock": {
		"id": "LockIdentifier",
		"lock_for": "LockFor",
		"lock_reasons": "LockReasons"
	},
	"LockReasons": {
		"_enum": {
			"Fee": null,
			"Misc": null,
			"All": null
		}
	}
}
```

Staking -> Payouts -> Own stashes

cc @WoeOm 