### PR TITLE
Use `sccache` for Cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,6 +274,8 @@ jobs:
         uses: actions/checkout@v2
       - name: DVM test
         run: |
+          pwd
+          ls -al
           cd tests/dvm
           npm install
           npm test


### PR DESCRIPTION
A full release build takes around 1 hour.
There are around 1600 packages if we enable try runtime feature, which takes longer.

With `sccache`, we could speed up the whole process.