### PR TITLE
Use Nightly Toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
     name: Build subalfred
     runs-on: ubuntu-latest
     steps:
-      - name: Install Rust nightly-2021-04-22 toolchain
+      - name: Install Rust nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-04-22
+          toolchain: nightly
           default: true
       - name: Install sccache
         env:
@@ -62,10 +62,10 @@ jobs:
     name: Check Rust code
     runs-on: ubuntu-latest
     steps:
-      - name: Install Rust nightly-2021-04-22 toolchain
+      - name: Install Rust nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-04-22
+          toolchain: nightly
           target: wasm32-unknown-unknown
           default: true
       - name: Install sccache
@@ -99,10 +99,10 @@ jobs:
     name: Build node and internal test
     runs-on: ubuntu-latest
     steps:
-      - name: Install Rust nightly-2021-04-22 toolchain
+      - name: Install Rust nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2021-04-22
+          toolchain: nightly
           target: wasm32-unknown-unknown
           default: true
       - name: Install sccache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9252,7 +9252,8 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "3.0.0"
-source = "git+https://github.com/darwinia-network/substrate?tag=darwinia-v0.11.6-1#3c951d7eb441b8dec5f438084b0c264422385069"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e80275f23b4e7ba8f54dec5f90f016530e7307d2ee9445f617ab986cbe97f31e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9262,8 +9263,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e80275f23b4e7ba8f54dec5f90f016530e7307d2ee9445f617ab986cbe97f31e"
+source = "git+https://github.com/darwinia-network/substrate?tag=darwinia-v0.11.6-1#3c951d7eb441b8dec5f438084b0c264422385069"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel    = "nightly-2021-04-22"
+channel    = "nightly"
 components = ["cargo", "clippy", "rustc", "rustfmt", "rust-src"]
 profile    = "minimal"
 targets    = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
#879 fixed.
So, release the lock and go to enjoy the latest Rust features.