### PR TITLE
Fix compile in benchmark mode

### DIFF
--- a/frame/wormhole/issuing/s2s/src/benchmarking.rs
+++ b/frame/wormhole/issuing/s2s/src/benchmarking.rs
@@ -23,7 +23,7 @@ use crate::Pallet as S2sIssuing;
 
 use array_bytes::{hex2bytes_unchecked, hex_into_unchecked};
 use darwinia_evm::Runner;
-use dp_asset::token::{TokenMetadata, NATIVE_TOKEN_TYPE};
+use dp_asset::{TokenMetadata, NATIVE_TOKEN_TYPE};
 use frame_benchmarking::benchmarks;
 use frame_support::assert_ok;
 use frame_system::RawOrigin;


### PR DESCRIPTION
```rs
$ cargo check --release --features runtime-benchmarks
error[E0432]: unresolved import `dp_asset::token`
  --> frame/wormhole/issuing/s2s/src/benchmarking.rs:26:15
   |
26 | use dp_asset::token::{TokenMetadata, NATIVE_TOKEN_TYPE};
   |               ^^^^^ could not find `token` in `dp_asset`

For more information about this error, try `rustc --explain E0432`.
error: could not compile `from-substrate-issuing` due to previous error
warning: build failed, waiting for other jobs to finish...

```