### PR TITLE
Fix Sync State

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,7 +1141,7 @@ dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
- "itertools 0.10.1",
+ "itertools 0.10.3",
  "log",
  "serde",
  "smallvec 1.7.0",
@@ -1169,7 +1169,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "csv",
- "itertools 0.10.1",
+ "itertools 0.10.3",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -1191,7 +1191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
 dependencies = [
  "cast",
- "itertools 0.10.1",
+ "itertools 0.10.3",
 ]
 
 [[package]]
@@ -2956,7 +2956,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2974,7 +2974,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2993,7 +2993,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "Inflector",
  "chrono",
@@ -3019,7 +3019,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3032,7 +3032,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3047,7 +3047,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "14.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -3058,7 +3058,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -3084,7 +3084,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
@@ -3096,7 +3096,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 1.1.0",
@@ -3108,7 +3108,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3118,7 +3118,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -3135,7 +3135,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3149,7 +3149,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3158,7 +3158,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4066,9 +4066,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
@@ -5603,7 +5603,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5619,7 +5619,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5634,7 +5634,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5648,7 +5648,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5671,7 +5671,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5685,7 +5685,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5755,7 +5755,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5771,7 +5771,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-election-provider-support",
  "frame-support",
@@ -5790,7 +5790,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5812,7 +5812,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -5827,7 +5827,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5845,7 +5845,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5860,7 +5860,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5874,7 +5874,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5890,7 +5890,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5904,7 +5904,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5917,7 +5917,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -5931,7 +5931,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5946,7 +5946,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5966,7 +5966,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5979,7 +5979,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5992,7 +5992,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6009,7 +6009,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6023,7 +6023,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6039,7 +6039,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -6056,7 +6056,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -6067,7 +6067,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6082,7 +6082,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6663,9 +6663,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
+checksum = "d1a3ea4f0dd7f1f3e512cf97bf100819aa547f36a6eccac8dbaae839eb92363e"
 
 [[package]]
 name = "plain_hasher"
@@ -7218,7 +7218,7 @@ dependencies = [
 [[package]]
 name = "remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "env_logger 0.8.4",
  "hex",
@@ -7477,7 +7477,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "log",
  "sp-core",
@@ -7488,7 +7488,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7517,7 +7517,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "futures 0.3.18",
  "futures-timer 3.0.2",
@@ -7540,7 +7540,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -7556,7 +7556,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7572,7 +7572,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2",
@@ -7583,7 +7583,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "chrono",
  "fdlimit",
@@ -7621,7 +7621,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "derive_more",
  "fnv",
@@ -7655,7 +7655,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -7684,7 +7684,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "async-trait",
  "futures 0.3.18",
@@ -7709,7 +7709,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7741,7 +7741,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7788,7 +7788,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "derive_more",
  "futures 0.3.18",
@@ -7812,7 +7812,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -7825,7 +7825,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -7861,7 +7861,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "async-trait",
  "futures 0.3.18",
@@ -7890,7 +7890,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "sc-client-api",
  "sp-authorship",
@@ -7901,7 +7901,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -7930,7 +7930,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -7947,7 +7947,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7962,7 +7962,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -7982,7 +7982,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8023,7 +8023,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "derive_more",
  "finality-grandpa",
@@ -8047,7 +8047,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "ansi_term",
  "futures 0.3.18",
@@ -8065,7 +8065,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8085,7 +8085,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -8104,7 +8104,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "async-std",
  "async-trait",
@@ -8159,7 +8159,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "futures 0.3.18",
  "futures-timer 3.0.2",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -8204,7 +8204,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "futures 0.3.18",
  "libp2p",
@@ -8217,7 +8217,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.9.0"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -8226,7 +8226,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "futures 0.3.18",
  "hash-db",
@@ -8261,7 +8261,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "derive_more",
  "futures 0.3.18",
@@ -8286,7 +8286,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "futures 0.1.31",
  "jsonrpc-core",
@@ -8304,7 +8304,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "async-trait",
  "directories",
@@ -8372,7 +8372,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8387,7 +8387,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -8409,7 +8409,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "chrono",
  "futures 0.3.18",
@@ -8429,7 +8429,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "ansi_term",
  "atty",
@@ -8466,7 +8466,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2",
@@ -8477,7 +8477,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "derive_more",
  "futures 0.3.18",
@@ -8506,7 +8506,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "derive_more",
  "futures 0.3.18",
@@ -8968,7 +8968,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "hash-db",
  "log",
@@ -8985,7 +8985,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate 1.1.0",
@@ -8997,7 +8997,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -9009,7 +9009,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -9023,7 +9023,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9035,7 +9035,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9047,7 +9047,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9059,7 +9059,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "futures 0.3.18",
  "log",
@@ -9077,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "async-trait",
  "futures 0.3.18",
@@ -9103,7 +9103,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9120,7 +9120,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "async-trait",
  "merlin",
@@ -9142,7 +9142,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "parity-scale-codec",
  "sp-arithmetic",
@@ -9152,7 +9152,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -9164,7 +9164,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -9208,7 +9208,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "kvdb",
  "parking_lot 0.11.2",
@@ -9228,7 +9228,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "3.0.0"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9238,7 +9238,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -9249,7 +9249,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -9266,7 +9266,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -9280,7 +9280,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "futures 0.3.18",
  "hash-db",
@@ -9305,7 +9305,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -9316,7 +9316,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -9333,7 +9333,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "ruzstd",
  "zstd",
@@ -9342,7 +9342,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -9355,7 +9355,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2",
@@ -9366,7 +9366,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -9376,7 +9376,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "3.0.0"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "backtrace",
 ]
@@ -9384,7 +9384,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -9395,7 +9395,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -9416,7 +9416,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -9433,7 +9433,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "Inflector",
  "proc-macro-crate 1.1.0",
@@ -9445,7 +9445,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "3.0.0"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "serde",
  "serde_json",
@@ -9454,7 +9454,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9467,7 +9467,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -9477,7 +9477,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "hash-db",
  "log",
@@ -9500,12 +9500,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 
 [[package]]
 name = "sp-storage"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9518,7 +9518,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "log",
  "sp-core",
@@ -9531,7 +9531,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "async-trait",
  "futures-timer 3.0.2",
@@ -9548,7 +9548,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "erased-serde",
  "log",
@@ -9566,7 +9566,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -9575,7 +9575,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "async-trait",
  "log",
@@ -9590,7 +9590,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -9604,7 +9604,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "futures 0.3.18",
  "futures-core",
@@ -9616,7 +9616,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9631,7 +9631,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-crate 1.1.0",
@@ -9643,7 +9643,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -9784,7 +9784,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "platforms",
 ]
@@ -9803,7 +9803,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.18",
@@ -9826,7 +9826,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.9.0"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "async-std",
  "derive_more",
@@ -9840,7 +9840,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "futures 0.3.18",
  "substrate-test-utils-derive",
@@ -9850,7 +9850,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils-derive"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "quote",
@@ -9860,7 +9860,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "ansi_term",
  "atty",
@@ -10654,7 +10654,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#ddaa176d2e4e9d44f962fd4ab4bc0107cca5a1c5"
+source = "git+https://github.com/darwinia-network/substrate?branch=darwinia-v0.11.7#e892c2378f4f2cc7fd29814932eb3d8f0639c0d9"
 dependencies = [
  "frame-try-runtime",
  "log",

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -15,7 +15,7 @@ array-bytes = { version = "1.4" }
 codec       = { package = "parity-scale-codec", version = "2.1" }
 futures     = { version = "0.3" }
 rand        = { version = "0.8" }
-serde       = { version = "1.0" }
+serde       = { version = "1.0", features = ["derive"] }
 serde_json  = { version = "1.0" }
 # darwinia-network
 darwinia-balances-rpc-runtime-api   = { path = "../../frame/balances/rpc/runtime-api" }

--- a/node/service/src/chain_spec/mod.rs
+++ b/node/service/src/chain_spec/mod.rs
@@ -28,21 +28,19 @@ pub mod template;
 pub use template::ChainSpec as TemplateChainSpec;
 
 // --- crates.io ---
-// use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 // --- paritytech ---
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
-use sc_chain_spec::{ChainType, GenericChainSpec, Properties};
-// use sc_chain_spec::ChainSpecExtension;
-// use sc_client_api::{BadBlocks, ForkBlocks};
+use sc_chain_spec::{ChainSpecExtension, ChainType, GenericChainSpec, Properties};
+use sc_client_api::{BadBlocks, ForkBlocks};
 use sc_finality_grandpa::AuthorityId as GrandpaId;
-// use sc_sync_state_rpc::LightSyncStateExtension;
+use sc_sync_state_rpc::LightSyncStateExtension;
 use sp_authority_discovery::AuthorityId as AuthorityDiscoveryId;
 use sp_consensus_babe::AuthorityId as BabeId;
 use sp_core::{sr25519, Pair, Public};
 use sp_runtime::traits::IdentifyAccount;
 // --- darwinia-network ---
-use drml_common_primitives::{AccountId, AccountPublic};
-// use drml_common_primitives::OpaqueBlock;
+use drml_common_primitives::{AccountId, AccountPublic, OpaqueBlock};
 
 const DEFAULT_PROTOCOL_ID: &str = "drml";
 
@@ -71,21 +69,20 @@ const TEAM_MEMBERS: &[&str] = &[
 	"0x88d388115bd0df43e805b029207cfa4925cecfb29026e345979d9b0004466c49",
 ];
 
-// TODO: next version
-// /// Node `ChainSpec` extensions.
-// ///
-// /// Additional parameters for some Substrate core modules,
-// /// customizable from the chain spec.
-// #[derive(Default, Clone, Serialize, Deserialize, ChainSpecExtension)]
-// #[serde(rename_all = "camelCase")]
-// pub struct Extensions {
-// 	/// Block numbers with known hashes.
-// 	pub fork_blocks: ForkBlocks<OpaqueBlock>,
-// 	/// Known bad block hashes.
-// 	pub bad_blocks: BadBlocks<OpaqueBlock>,
-// 	/// The light sync state extension used by the sync-state rpc.
-// 	pub light_sync_state: LightSyncStateExtension,
-// }
+/// Node `ChainSpec` extensions.
+///
+/// Additional parameters for some Substrate core modules,
+/// customizable from the chain spec.
+#[derive(Default, Clone, Serialize, Deserialize, ChainSpecExtension)]
+#[serde(rename_all = "camelCase")]
+pub struct Extensions {
+	/// Block numbers with known hashes.
+	pub fork_blocks: ForkBlocks<OpaqueBlock>,
+	/// Known bad block hashes.
+	pub bad_blocks: BadBlocks<OpaqueBlock>,
+	/// The light sync state extension used by the sync-state rpc.
+	pub light_sync_state: LightSyncStateExtension,
+}
 
 /// Generate a crypto pair from seed.
 pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {

--- a/node/service/src/chain_spec/pangolin.rs
+++ b/node/service/src/chain_spec/pangolin.rs
@@ -36,9 +36,7 @@ use darwinia_evm::GenesisAccount;
 use drml_common_primitives::*;
 use pangolin_runtime::*;
 
-// TODO: next version
-// pub type ChainSpec = GenericChainSpec<GenesisConfig, Extensions>;
-pub type ChainSpec = GenericChainSpec<GenesisConfig>;
+pub type ChainSpec = GenericChainSpec<GenesisConfig, Extensions>;
 
 const PANGOLIN_TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";
 

--- a/node/service/src/chain_spec/pangoro.rs
+++ b/node/service/src/chain_spec/pangoro.rs
@@ -34,9 +34,7 @@ use darwinia_staking::StakerStatus;
 use drml_common_primitives::*;
 use pangoro_runtime::*;
 
-// TODO: next version
-// pub type ChainSpec = GenericChainSpec<GenesisConfig, Extensions>;
-pub type ChainSpec = GenericChainSpec<GenesisConfig>;
+pub type ChainSpec = GenericChainSpec<GenesisConfig, Extensions>;
 
 const PANGORO_TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";
 


### PR DESCRIPTION
> ```
> This decouples the light-sync state from chain spec. First, the
> light-sync state currently only works with BABE+Grandpa, so not
> all Substrate based chains can use this feature. The next problem was
> also that this pulled the sc-consensus-babe and sc-finality-grandpa
> crate into sc-chain-spec.
>
> If a chain now wants to support the light-sync state, it needs to add
> the LightSyncStateExtension to the chain spec as an extension. This is
> documented in the crate level docs of sc-sync-state-rpc. If this
> extension is not available, SyncStateRpc fails at initialization.
> ```

If we disable this extension the node will fail to boot.