### PR TITLE
Update evm crates path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2858,7 +2858,7 @@ checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 [[package]]
 name = "evm"
 version = "0.30.1"
-source = "git+https://github.com/darwinia-network/evm?branch=darwinia-v0.11.8#a93227686a2fd4f6e02c77e5d7a7104f98cf4a49"
+source = "git+https://github.com/darwinia-network/evm?branch=v0.30-runtime-override#0a6a3374e80d78598d14048e766c17c09183d5c8"
 dependencies = [
  "environmental",
  "ethereum",
@@ -2876,7 +2876,7 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.30.0"
-source = "git+https://github.com/darwinia-network/evm?branch=darwinia-v0.11.8#a93227686a2fd4f6e02c77e5d7a7104f98cf4a49"
+source = "git+https://github.com/darwinia-network/evm?branch=v0.30-runtime-override#0a6a3374e80d78598d14048e766c17c09183d5c8"
 dependencies = [
  "funty",
  "parity-scale-codec",
@@ -2887,7 +2887,7 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.30.0"
-source = "git+https://github.com/darwinia-network/evm?branch=darwinia-v0.11.8#a93227686a2fd4f6e02c77e5d7a7104f98cf4a49"
+source = "git+https://github.com/darwinia-network/evm?branch=v0.30-runtime-override#0a6a3374e80d78598d14048e766c17c09183d5c8"
 dependencies = [
  "environmental",
  "evm-core",
@@ -2898,7 +2898,7 @@ dependencies = [
 [[package]]
 name = "evm-runtime"
 version = "0.30.0"
-source = "git+https://github.com/darwinia-network/evm?branch=darwinia-v0.11.8#a93227686a2fd4f6e02c77e5d7a7104f98cf4a49"
+source = "git+https://github.com/darwinia-network/evm?branch=v0.30-runtime-override#0a6a3374e80d78598d14048e766c17c09183d5c8"
 dependencies = [
  "environmental",
  "evm-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2858,7 +2858,7 @@ checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 [[package]]
 name = "evm"
 version = "0.30.1"
-source = "git+https://github.com/darwinia-network/evm?branch=v0.30-runtime-override#0a6a3374e80d78598d14048e766c17c09183d5c8"
+source = "git+https://github.com/darwinia-network/evm?branch=darwinia-v0.11.8#a93227686a2fd4f6e02c77e5d7a7104f98cf4a49"
 dependencies = [
  "environmental",
  "ethereum",
@@ -2876,7 +2876,7 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.30.0"
-source = "git+https://github.com/darwinia-network/evm?branch=v0.30-runtime-override#0a6a3374e80d78598d14048e766c17c09183d5c8"
+source = "git+https://github.com/darwinia-network/evm?branch=darwinia-v0.11.8#a93227686a2fd4f6e02c77e5d7a7104f98cf4a49"
 dependencies = [
  "funty",
  "parity-scale-codec",
@@ -2887,7 +2887,7 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.30.0"
-source = "git+https://github.com/darwinia-network/evm?branch=v0.30-runtime-override#0a6a3374e80d78598d14048e766c17c09183d5c8"
+source = "git+https://github.com/darwinia-network/evm?branch=darwinia-v0.11.8#a93227686a2fd4f6e02c77e5d7a7104f98cf4a49"
 dependencies = [
  "environmental",
  "evm-core",
@@ -2898,7 +2898,7 @@ dependencies = [
 [[package]]
 name = "evm-runtime"
 version = "0.30.0"
-source = "git+https://github.com/darwinia-network/evm?branch=v0.30-runtime-override#0a6a3374e80d78598d14048e766c17c09183d5c8"
+source = "git+https://github.com/darwinia-network/evm?branch=darwinia-v0.11.8#a93227686a2fd4f6e02c77e5d7a7104f98cf4a49"
 dependencies = [
  "environmental",
  "evm-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,9 +76,9 @@ members = [
 ]
 
 [patch.crates-io]
-evm           = { git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
-evm-gasometer = { git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
-evm-runtime   = { git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
+evm           = { git = "https://github.com/darwinia-network/evm", branch = "v0.30-runtime-override" }
+evm-gasometer = { git = "https://github.com/darwinia-network/evm", branch = "v0.30-runtime-override" }
+evm-runtime   = { git = "https://github.com/darwinia-network/evm", branch = "v0.30-runtime-override" }
 
 # The list of dependencies below (which can be both direct and indirect dependencies) are crates
 # that are suspected to be CPU-intensive, and that are unlikely to require debugging (as some of

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,11 @@ members = [
 	"primitives/storage",
 ]
 
+[patch.crates-io]
+evm           = { git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
+evm-gasometer = { git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
+evm-runtime   = { git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
+
 # The list of dependencies below (which can be both direct and indirect dependencies) are crates
 # that are suspected to be CPU-intensive, and that are unlikely to require debugging (as some of
 # their debug info might be missing) or to require to be frequently recompiled. We compile these

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,9 +76,9 @@ members = [
 ]
 
 [patch.crates-io]
-evm           = { git = "https://github.com/darwinia-network/evm", branch = "v0.30-runtime-override" }
-evm-gasometer = { git = "https://github.com/darwinia-network/evm", branch = "v0.30-runtime-override" }
-evm-runtime   = { git = "https://github.com/darwinia-network/evm", branch = "v0.30-runtime-override" }
+evm           = { git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
+evm-gasometer = { git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
+evm-runtime   = { git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
 
 # The list of dependencies below (which can be both direct and indirect dependencies) are crates
 # that are suspected to be CPU-intensive, and that are unlikely to require debugging (as some of

--- a/client/dvm/rpc/Cargo.toml
+++ b/client/dvm/rpc/Cargo.toml
@@ -37,7 +37,7 @@ dp-storage          = { path = "../../../primitives/storage/" }
 dvm-ethereum        = { path = "../../../frame/dvm" }
 dvm-rpc-core        = { path = "../../../frame/dvm/rpc" }
 dvm-rpc-runtime-api = { path = "../../../frame/dvm/rpc/runtime-api" }
-evm                 = { git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
+evm                 = { version = "0.30" }
 # paritytech
 sc-client-api           = { git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
 sc-network              = { git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }

--- a/client/dvm/rpc/Cargo.toml
+++ b/client/dvm/rpc/Cargo.toml
@@ -15,6 +15,7 @@ array-bytes         = { version = "1.4" }
 codec               = { package = "parity-scale-codec", version = "2.1" }
 ethereum            = { version = "0.9", features = ["with-codec"] }
 ethereum-types      = { version = "0.12" }
+evm                 = { version = "0.30" }
 futures             = { version = "0.3", features = ["compat"] }
 jsonrpc-core        = { version = "15.1" }
 jsonrpc-core-client = { version = "15.1" }
@@ -37,7 +38,6 @@ dp-storage          = { path = "../../../primitives/storage/" }
 dvm-ethereum        = { path = "../../../frame/dvm" }
 dvm-rpc-core        = { path = "../../../frame/dvm/rpc" }
 dvm-rpc-runtime-api = { path = "../../../frame/dvm/rpc/runtime-api" }
-evm                 = { version = "0.30" }
 # paritytech
 sc-client-api           = { git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
 sc-network              = { git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }

--- a/frame/dvm/Cargo.toml
+++ b/frame/dvm/Cargo.toml
@@ -14,6 +14,7 @@ version     = "2.7.2"
 codec          = { package = "parity-scale-codec", version = "2.1", default-features = false }
 ethereum       = { version = "0.9", default-features = false, features = ["with-codec"] }
 ethereum-types = { version = "0.12", default-features = false }
+evm            = { version = "0.30", default-features = false, features = ["with-codec"] }
 libsecp256k1   = { version = "0.5", default-features = false, features = ["static-context", "hmac"] }
 log            = { version = "0.4" }
 rlp            = { version = "0.5", default-features = false }
@@ -26,7 +27,6 @@ dp-consensus        = { default-features = false, path = "../../primitives/conse
 dp-evm              = { default-features = false, path = "../../primitives/evm" }
 dp-storage          = { default-features = false, path = "../../primitives/storage" }
 dvm-rpc-runtime-api = { default-features = false, path = "./rpc/runtime-api" }
-evm                 = { default-features = false, features = ["with-codec"], version = "0.30" }
 # paritytech
 frame-support    = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
 frame-system     = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }

--- a/frame/dvm/Cargo.toml
+++ b/frame/dvm/Cargo.toml
@@ -26,7 +26,7 @@ dp-consensus        = { default-features = false, path = "../../primitives/conse
 dp-evm              = { default-features = false, path = "../../primitives/evm" }
 dp-storage          = { default-features = false, path = "../../primitives/storage" }
 dvm-rpc-runtime-api = { default-features = false, path = "./rpc/runtime-api" }
-evm                 = { default-features = false, features = ["with-codec"], git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
+evm                 = { default-features = false, features = ["with-codec"], version = "0.30" }
 # paritytech
 frame-support    = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
 frame-system     = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }

--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -13,6 +13,9 @@ version     = "2.7.2"
 # crates.io
 array-bytes     = { version = "1.4" }
 codec           = { package = "parity-scale-codec", version = "2.1", default-features = false }
+evm             = { version = "0.30", default-features = false, features = ["with-codec"] }
+evm-gasometer   = { version = "0.30", default-features = false }
+evm-runtime     = { version = "0.30", default-features = false }
 log             = { version = "0.4" }
 primitive-types = { version = "0.10", default-features = false, features = ["rlp", "byteorder"] }
 rlp             = { version = "0.5", default-features = false }
@@ -22,9 +25,6 @@ sha3            = { version = "0.9", default-features = false }
 darwinia-balances = { default-features = false, path = "../balances" }
 darwinia-support  = { default-features = false, path = "../support" }
 dp-evm            = { default-features = false, path = "../../primitives/evm" }
-evm               = { default-features = false, features = ["with-codec"], version = "0.30" }
-evm-gasometer     = { default-features = false, version = "0.30" }
-evm-runtime       = { default-features = false, version = "0.30" }
 # paritytech
 frame-benchmarking = { optional = true, default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
 frame-support      = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
@@ -45,6 +45,10 @@ default = ["std"]
 std = [
 	# crates.io
 	"codec/std",
+	"evm/std",
+	"evm/with-serde",
+	"evm-gasometer/std",
+	"evm-runtime/std",
 	"primitive-types/std",
 	"rlp/std",
 	"serde",
@@ -53,10 +57,6 @@ std = [
 	"darwinia-balances/std",
 	"darwinia-support/std",
 	"dp-evm/std",
-	"evm/std",
-	"evm/with-serde",
-	"evm-gasometer/std",
-	"evm-runtime/std",
 	# paritytech
 	"frame-benchmarking/std",
 	"frame-support/std",

--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -22,9 +22,9 @@ sha3            = { version = "0.9", default-features = false }
 darwinia-balances = { default-features = false, path = "../balances" }
 darwinia-support  = { default-features = false, path = "../support" }
 dp-evm            = { default-features = false, path = "../../primitives/evm" }
-evm               = { default-features = false, features = ["with-codec"], git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
-evm-gasometer     = { default-features = false, git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
-evm-runtime       = { default-features = false, git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
+evm               = { default-features = false, features = ["with-codec"], version = "0.30" }
+evm-gasometer     = { default-features = false, version = "0.30" }
+evm-runtime       = { default-features = false, version = "0.30" }
 # paritytech
 frame-benchmarking = { optional = true, default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
 frame-support      = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }

--- a/frame/evm/precompile/contracts/blake2/Cargo.toml
+++ b/frame/evm/precompile/contracts/blake2/Cargo.toml
@@ -12,7 +12,7 @@ version     = "2.7.2"
 
 [dependencies]
 # crates.io
-evm    = { version = "0.30", default-features = false, features = ["with-codec"] }
+evm = { version = "0.30", default-features = false, features = ["with-codec"] }
 # darwinia-network
 dp-evm = { default-features = false, path = "../../../../../primitives/evm" }
 # paritytech

--- a/frame/evm/precompile/contracts/blake2/Cargo.toml
+++ b/frame/evm/precompile/contracts/blake2/Cargo.toml
@@ -11,10 +11,10 @@ version     = "2.7.2"
 
 
 [dependencies]
+# crates.io
+evm    = { version = "0.30", default-features = false, features = ["with-codec"] }
 # darwinia-network
 dp-evm = { default-features = false, path = "../../../../../primitives/evm" }
-evm    = { default-features = false, features = ["with-codec"], version = "0.30" }
-
 # paritytech
 sp-core = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
 sp-io   = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
@@ -23,9 +23,10 @@ sp-io   = { default-features = false, git = "https://github.com/darwinia-network
 default = ["std"]
 
 std = [
+	# crates.io
+	"evm/std",
 	# darwinia-network
 	"dp-evm/std",
-	"evm/std",
 	# paritytech
 	"sp-core/std",
 	"sp-io/std",

--- a/frame/evm/precompile/contracts/blake2/Cargo.toml
+++ b/frame/evm/precompile/contracts/blake2/Cargo.toml
@@ -13,7 +13,7 @@ version     = "2.7.2"
 [dependencies]
 # darwinia-network
 dp-evm = { default-features = false, path = "../../../../../primitives/evm" }
-evm    = { default-features = false, features = ["with-codec"], git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
+evm    = { default-features = false, features = ["with-codec"], version = "0.30" }
 
 # paritytech
 sp-core = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }

--- a/frame/evm/precompile/contracts/bn128/Cargo.toml
+++ b/frame/evm/precompile/contracts/bn128/Cargo.toml
@@ -15,7 +15,7 @@ version     = "2.7.2"
 bn = { package = "substrate-bn", version = "0.6" }
 # darwinia-network
 dp-evm = { default-features = false, path = "../../../../../primitives/evm" }
-evm    = { default-features = false, features = ["with-codec"], git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
+evm    = { default-features = false, features = ["with-codec"], version = "0.30" }
 # paritytech
 sp-core = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
 sp-io   = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }

--- a/frame/evm/precompile/contracts/bn128/Cargo.toml
+++ b/frame/evm/precompile/contracts/bn128/Cargo.toml
@@ -12,10 +12,10 @@ version     = "2.7.2"
 
 [dependencies]
 # crates.io
-bn = { package = "substrate-bn", version = "0.6" }
+bn  = { package = "substrate-bn", version = "0.6" }
+evm = { version = "0.30", default-features = false, features = ["with-codec"] }
 # darwinia-network
 dp-evm = { default-features = false, path = "../../../../../primitives/evm" }
-evm    = { default-features = false, features = ["with-codec"], version = "0.30" }
 # paritytech
 sp-core = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
 sp-io   = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
@@ -24,9 +24,10 @@ sp-io   = { default-features = false, git = "https://github.com/darwinia-network
 default = ["std"]
 
 std = [
+	# crates.io
+	"evm/std",
 	# darwinia-network
 	"dp-evm/std",
-	"evm/std",
 	# paritytech
 	"sp-core/std",
 	"sp-io/std",

--- a/frame/evm/precompile/contracts/bridge/ethereum/Cargo.toml
+++ b/frame/evm/precompile/contracts/bridge/ethereum/Cargo.toml
@@ -13,11 +13,11 @@ version     = "2.7.2"
 [dependencies]
 # crates.io
 codec = { package = "parity-scale-codec", version = "2.1", default-features = false }
+evm   = { version = "0.30", default-features = false, features = ["with-codec"] }
 # darwinia-network
 darwinia-evm                  = { default-features = false, path = "../../../../../evm" }
 darwinia-evm-precompile-utils = { default-features = false, path = "../../utils" }
 dp-evm                        = { default-features = false, path = "../../../../../../primitives/evm" }
-evm                           = { default-features = false, features = ["with-codec"], version = "0.30" }
 from-ethereum-issuing         = { default-features = false, path = "../../../../../wormhole/issuing/ethereum" }
 # paritytech
 sp-core = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
@@ -30,11 +30,11 @@ default = ["std"]
 std = [
 	# crates.io
 	"codec/std",
+	"evm/std",
 	# darwinia-network
 	"darwinia-evm/std",
 	"darwinia-evm-precompile-utils/std",
 	"dp-evm/std",
-	"evm/std",
 	"from-ethereum-issuing/std",
 	# paritytech
 	"sp-core/std",

--- a/frame/evm/precompile/contracts/bridge/ethereum/Cargo.toml
+++ b/frame/evm/precompile/contracts/bridge/ethereum/Cargo.toml
@@ -17,7 +17,7 @@ codec = { package = "parity-scale-codec", version = "2.1", default-features = fa
 darwinia-evm                  = { default-features = false, path = "../../../../../evm" }
 darwinia-evm-precompile-utils = { default-features = false, path = "../../utils" }
 dp-evm                        = { default-features = false, path = "../../../../../../primitives/evm" }
-evm                           = { default-features = false, features = ["with-codec"], git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
+evm                           = { default-features = false, features = ["with-codec"], version = "0.30" }
 from-ethereum-issuing         = { default-features = false, path = "../../../../../wormhole/issuing/ethereum" }
 # paritytech
 sp-core = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }

--- a/frame/evm/precompile/contracts/bridge/s2s/Cargo.toml
+++ b/frame/evm/precompile/contracts/bridge/s2s/Cargo.toml
@@ -20,7 +20,7 @@ darwinia-support              = { default-features = false, path = "../../../../
 dp-contract                   = { default-features = false, path = "../../../../../../primitives/contract" }
 dp-evm                        = { default-features = false, path = "../../../../../../primitives/evm" }
 dp-s2s                        = { default-features = false, path = "../../../../../../primitives/s2s" }
-evm                           = { default-features = false, features = ["with-codec"], git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
+evm                           = { default-features = false, features = ["with-codec"], version = "0.30" }
 from-substrate-issuing        = { default-features = false, path = "../../../../../wormhole/issuing/s2s" }
 # paritytech
 bp-message-dispatch = { default-features = false, git = "https://github.com/darwinia-network/parity-bridges-common", branch = "darwinia-v0.11.8" }

--- a/frame/evm/precompile/contracts/bridge/s2s/Cargo.toml
+++ b/frame/evm/precompile/contracts/bridge/s2s/Cargo.toml
@@ -12,6 +12,7 @@ version     = "2.7.2"
 [dependencies]
 # crates.io
 codec = { package = "parity-scale-codec", version = "2.1", default-features = false }
+evm   = { version = "0.30", default-features = false, features = ["with-codec"] }
 log   = { version = "0.4" }
 # darwinia-network
 darwinia-evm                  = { default-features = false, path = "../../../../../evm" }
@@ -20,7 +21,6 @@ darwinia-support              = { default-features = false, path = "../../../../
 dp-contract                   = { default-features = false, path = "../../../../../../primitives/contract" }
 dp-evm                        = { default-features = false, path = "../../../../../../primitives/evm" }
 dp-s2s                        = { default-features = false, path = "../../../../../../primitives/s2s" }
-evm                           = { default-features = false, features = ["with-codec"], version = "0.30" }
 from-substrate-issuing        = { default-features = false, path = "../../../../../wormhole/issuing/s2s" }
 # paritytech
 bp-message-dispatch = { default-features = false, git = "https://github.com/darwinia-network/parity-bridges-common", branch = "darwinia-v0.11.8" }
@@ -36,6 +36,7 @@ default = ["std"]
 std = [
 	# crates.io
 	"codec/std",
+	"evm/std",
 	# darwinia-network
 	"darwinia-evm-precompile-utils/std",
 	"darwinia-evm/std",
@@ -43,7 +44,6 @@ std = [
 	"dp-contract/std",
 	"dp-evm/std",
 	"dp-s2s/std",
-	"evm/std",
 	"from-substrate-issuing/std",
 	# paritytech
 	"bp-message-dispatch/std",

--- a/frame/evm/precompile/contracts/curve25519/Cargo.toml
+++ b/frame/evm/precompile/contracts/curve25519/Cargo.toml
@@ -14,7 +14,7 @@ version     = "2.7.2"
 curve25519-dalek = { version = "3.0", default-features = false, features = ["alloc", "u64_backend"] }
 # darwinia-network
 dp-evm = { default-features = false, path = "../../../../../primitives/evm" }
-evm    = { default-features = false, features = ["with-codec"], git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
+evm    = { default-features = false, features = ["with-codec"], version = "0.30" }
 # paritytech
 sp-core = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
 sp-io   = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }

--- a/frame/evm/precompile/contracts/curve25519/Cargo.toml
+++ b/frame/evm/precompile/contracts/curve25519/Cargo.toml
@@ -12,9 +12,9 @@ version     = "2.7.2"
 [dependencies]
 # crates.io
 curve25519-dalek = { version = "3.0", default-features = false, features = ["alloc", "u64_backend"] }
+evm              = { version = "0.30", default-features = false, features = ["with-codec"] }
 # darwinia-network
 dp-evm = { default-features = false, path = "../../../../../primitives/evm" }
-evm    = { default-features = false, features = ["with-codec"], version = "0.30" }
 # paritytech
 sp-core = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
 sp-io   = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
@@ -25,9 +25,9 @@ default = ["std"]
 std = [
 	# crates.io
 	"curve25519-dalek/std",
+	"evm/std",
 	# darwinia-network
 	"dp-evm/std",
-	"evm/std",
 	# paritytech
 	"sp-core/std",
 	"sp-io/std",

--- a/frame/evm/precompile/contracts/dispatch/Cargo.toml
+++ b/frame/evm/precompile/contracts/dispatch/Cargo.toml
@@ -17,7 +17,7 @@ codec = { package = "parity-scale-codec", version = "2.1", default-features = fa
 darwinia-evm     = { default-features = false, path = "../../../../evm" }
 darwinia-support = { default-features = false, path = "../../../../support" }
 dp-evm           = { default-features = false, path = "../../../../../primitives/evm" }
-evm              = { default-features = false, features = ["with-codec"], git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
+evm              = { default-features = false, features = ["with-codec"], version = "0.30" }
 # paritytech
 frame-support = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
 sp-core       = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }

--- a/frame/evm/precompile/contracts/dispatch/Cargo.toml
+++ b/frame/evm/precompile/contracts/dispatch/Cargo.toml
@@ -13,11 +13,11 @@ version     = "2.7.2"
 [dependencies]
 # crates.io
 codec = { package = "parity-scale-codec", version = "2.1", default-features = false }
+evm   = { version = "0.30", default-features = false, features = ["with-codec"] }
 # darwinia-network
 darwinia-evm     = { default-features = false, path = "../../../../evm" }
 darwinia-support = { default-features = false, path = "../../../../support" }
 dp-evm           = { default-features = false, path = "../../../../../primitives/evm" }
-evm              = { default-features = false, features = ["with-codec"], version = "0.30" }
 # paritytech
 frame-support = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
 sp-core       = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
@@ -29,11 +29,11 @@ default = ["std"]
 std = [
 	# crates.io
 	"codec/std",
+	"evm/std",
 	# darwinia-network
 	"darwinia-evm/std",
 	"darwinia-support/std",
 	"dp-evm/std",
-	"evm/std",
 	# paritytech
 	"frame-support/std",
 	"sp-core/std",

--- a/frame/evm/precompile/contracts/ed25519/Cargo.toml
+++ b/frame/evm/precompile/contracts/ed25519/Cargo.toml
@@ -14,7 +14,7 @@ version     = "2.7.2"
 ed25519-dalek = { version = "1.0", default-features = false, features = ["alloc", "u64_backend"] }
 # darwinia-network
 dp-evm = { default-features = false, path = "../../../../../primitives/evm" }
-evm    = { default-features = false, features = ["with-codec"], git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
+evm    = { default-features = false, features = ["with-codec"], version = "0.30" }
 # paritytech
 sp-core = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
 sp-io   = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }

--- a/frame/evm/precompile/contracts/ed25519/Cargo.toml
+++ b/frame/evm/precompile/contracts/ed25519/Cargo.toml
@@ -12,9 +12,9 @@ version     = "2.7.2"
 [dependencies]
 # crates.io
 ed25519-dalek = { version = "1.0", default-features = false, features = ["alloc", "u64_backend"] }
+evm           = { version = "0.30", default-features = false, features = ["with-codec"] }
 # darwinia-network
 dp-evm = { default-features = false, path = "../../../../../primitives/evm" }
-evm    = { default-features = false, features = ["with-codec"], version = "0.30" }
 # paritytech
 sp-core = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
 sp-io   = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
@@ -25,9 +25,9 @@ default = ["std"]
 std = [
 	# crates.io
 	"ed25519-dalek/std",
+	"evm/std",
 	# darwinia-network
 	"dp-evm/std",
-	"evm/std",
 	# paritytech
 	"sp-core/std",
 	"sp-io/std",

--- a/frame/evm/precompile/contracts/modexp/Cargo.toml
+++ b/frame/evm/precompile/contracts/modexp/Cargo.toml
@@ -15,7 +15,7 @@ version     = "2.7.2"
 dp-evm = { default-features = false, path = "../../../../../primitives/evm" }
 num    = { version = "0.3", default-features = false, features = ["alloc"] }
 # darwinia-network
-evm = { default-features = false, features = ["with-codec"], git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
+evm = { default-features = false, features = ["with-codec"], version = "0.30" }
 # paritytech
 sp-core = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
 sp-io   = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }

--- a/frame/evm/precompile/contracts/modexp/Cargo.toml
+++ b/frame/evm/precompile/contracts/modexp/Cargo.toml
@@ -14,8 +14,7 @@ version     = "2.7.2"
 # crates.io
 dp-evm = { default-features = false, path = "../../../../../primitives/evm" }
 num    = { version = "0.3", default-features = false, features = ["alloc"] }
-# darwinia-network
-evm = { default-features = false, features = ["with-codec"], version = "0.30" }
+evm    = { version = "0.30", default-features = false, features = ["with-codec"] }
 # paritytech
 sp-core = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
 sp-io   = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
@@ -29,9 +28,8 @@ default = ["std"]
 std = [
 	# crates.io
 	"dp-evm/std",
-	"num/std",
-	# darwinia-network
 	"evm/std",
+	"num/std",
 	# paritytech
 	"sp-core/std",
 	"sp-io/std",

--- a/frame/evm/precompile/contracts/sha3fips/Cargo.toml
+++ b/frame/evm/precompile/contracts/sha3fips/Cargo.toml
@@ -13,9 +13,9 @@ version     = "2.7.2"
 [dependencies]
 # crates.io
 dp-evm      = { default-features = false, path = "../../../../../primitives/evm" }
+evm         = { version = "0.30", default-features = false, features = ["with-codec"] }
 tiny-keccak = { version = "2.0", features = ["fips202"] }
 # darwinia-network
-evm = { default-features = false, features = ["with-codec"], version = "0.30" }
 # paritytech
 sp-core = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
 sp-io   = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
@@ -26,7 +26,6 @@ default = ["std"]
 std = [
 	# crates.io
 	"dp-evm/std",
-	# darwinia-network
 	"evm/std",
 	# paritytech
 	"sp-core/std",

--- a/frame/evm/precompile/contracts/sha3fips/Cargo.toml
+++ b/frame/evm/precompile/contracts/sha3fips/Cargo.toml
@@ -15,7 +15,7 @@ version     = "2.7.2"
 dp-evm      = { default-features = false, path = "../../../../../primitives/evm" }
 tiny-keccak = { version = "2.0", features = ["fips202"] }
 # darwinia-network
-evm = { default-features = false, features = ["with-codec"], git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
+evm = { default-features = false, features = ["with-codec"], version = "0.30" }
 # paritytech
 sp-core = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
 sp-io   = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }

--- a/frame/evm/precompile/contracts/simple/Cargo.toml
+++ b/frame/evm/precompile/contracts/simple/Cargo.toml
@@ -12,9 +12,8 @@ version     = "2.7.2"
 [dependencies]
 # crates.io
 dp-evm    = { default-features = false, path = "../../../../../primitives/evm" }
+evm       = { version = "0.30", default-features = false, features = ["with-codec"] }
 ripemd160 = { version = "0.9", default-features = false }
-# darwinia-network
-evm = { default-features = false, features = ["with-codec"], version = "0.30" }
 # paritytech
 sp-core = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
 sp-io   = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
@@ -25,9 +24,8 @@ default = ["std"]
 std = [
 	# crates.io
 	"dp-evm/std",
-	"ripemd160/std",
-	# darwinia-network
 	"evm/std",
+	"ripemd160/std",
 	# paritytech
 	"sp-core/std",
 	"sp-io/std",

--- a/frame/evm/precompile/contracts/simple/Cargo.toml
+++ b/frame/evm/precompile/contracts/simple/Cargo.toml
@@ -14,7 +14,7 @@ version     = "2.7.2"
 dp-evm    = { default-features = false, path = "../../../../../primitives/evm" }
 ripemd160 = { version = "0.9", default-features = false }
 # darwinia-network
-evm = { default-features = false, features = ["with-codec"], git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
+evm = { default-features = false, features = ["with-codec"], version = "0.30" }
 # paritytech
 sp-core = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
 sp-io   = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }

--- a/frame/evm/precompile/contracts/transfer/Cargo.toml
+++ b/frame/evm/precompile/contracts/transfer/Cargo.toml
@@ -15,6 +15,7 @@ array-bytes    = { version = "1.4" }
 codec          = { package = "parity-scale-codec", version = "2.1", default-features = false }
 ethabi         = { version = "15.0", default-features = false }
 ethereum-types = { version = "0.12", default-features = false }
+evm            = { version = "0.30", default-features = false, features = ["with-codec"] }
 log            = { version = "0.4" }
 ripemd160      = { version = "0.9", default-features = false }
 sha3           = { version = "0.9", default-features = false }
@@ -22,7 +23,6 @@ sha3           = { version = "0.9", default-features = false }
 darwinia-evm     = { default-features = false, path = "../../../" }
 darwinia-support = { default-features = false, path = "../../../../support" }
 dp-evm           = { default-features = false, path = "../../../../../primitives/evm" }
-evm              = { default-features = false, features = ["with-codec"], version = "0.30" }
 # paritytech
 frame-support    = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
 frame-system     = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
@@ -40,13 +40,13 @@ std = [
 	"codec/std",
 	"ethabi/std",
 	"ethereum-types/std",
+	"evm/std",
 	"ripemd160/std",
 	"sha3/std",
 	# darwinia-network
 	"darwinia-evm/std",
 	"darwinia-support/std",
 	"dp-evm/std",
-	"evm/std",
 	# paritytech
 	"frame-support/std",
 	"frame-system/std",

--- a/frame/evm/precompile/contracts/transfer/Cargo.toml
+++ b/frame/evm/precompile/contracts/transfer/Cargo.toml
@@ -22,7 +22,7 @@ sha3           = { version = "0.9", default-features = false }
 darwinia-evm     = { default-features = false, path = "../../../" }
 darwinia-support = { default-features = false, path = "../../../../support" }
 dp-evm           = { default-features = false, path = "../../../../../primitives/evm" }
-evm              = { default-features = false, features = ["with-codec"], git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
+evm              = { default-features = false, features = ["with-codec"], version = "0.30" }
 # paritytech
 frame-support    = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
 frame-system     = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }

--- a/frame/evm/precompile/contracts/utils/Cargo.toml
+++ b/frame/evm/precompile/contracts/utils/Cargo.toml
@@ -13,7 +13,7 @@ version     = "2.7.2"
 # darwinia-network
 darwinia-evm-precompile-utils-macro = { path = "macro" }
 darwinia-support                    = { default-features = false, path = "../../../../support" }
-evm                                 = { default-features = false, features = ["with-codec"], git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
+evm                                 = { default-features = false, features = ["with-codec"], version = "0.30" }
 
 [features]
 default = ["std"]

--- a/frame/evm/precompile/contracts/utils/Cargo.toml
+++ b/frame/evm/precompile/contracts/utils/Cargo.toml
@@ -10,16 +10,18 @@ repository  = "https://github.com/darwinia-network/darwinia-common"
 version     = "2.7.2"
 
 [dependencies]
+# crates.io
+evm = { version = "0.30", default-features = false, features = ["with-codec"] }
 # darwinia-network
 darwinia-evm-precompile-utils-macro = { path = "macro" }
 darwinia-support                    = { default-features = false, path = "../../../../support" }
-evm                                 = { default-features = false, features = ["with-codec"], version = "0.30" }
 
 [features]
 default = ["std"]
 
 std = [
+	# crates.io
+	"evm/std",
 	# darwinia-network
 	"darwinia-support/std",
-	"evm/std",
 ]

--- a/frame/evm/precompile/contracts/utils/macro/Cargo.toml
+++ b/frame/evm/precompile/contracts/utils/macro/Cargo.toml
@@ -14,12 +14,11 @@ proc-macro = true
 
 [dependencies]
 # crates.io
+evm         = { version = "0.30", default-features = false, features = ["with-codec"] }
 proc-macro2 = { version = "1.0" }
 quote       = { version = "1.0" }
 sha3        = { version = "0.9", default-features = false }
 syn         = { version = "1.0", features = ["full", "fold", "extra-traits", "visit"] }
-# darwinia-network
-evm = { default-features = false, features = ["with-codec"], version = "0.30" }
 # paritytech
 sp-std = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
 
@@ -28,9 +27,8 @@ default = ["std"]
 
 std = [
 	# crates.io
-	"sha3/std",
-	# darwinia-network
 	"evm/std",
+	"sha3/std",
 	# paritytech
 	"sp-std/std",
 ]

--- a/frame/evm/precompile/contracts/utils/macro/Cargo.toml
+++ b/frame/evm/precompile/contracts/utils/macro/Cargo.toml
@@ -19,7 +19,7 @@ quote       = { version = "1.0" }
 sha3        = { version = "0.9", default-features = false }
 syn         = { version = "1.0", features = ["full", "fold", "extra-traits", "visit"] }
 # darwinia-network
-evm = { default-features = false, features = ["with-codec"], git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
+evm = { default-features = false, features = ["with-codec"], version = "0.30" }
 # paritytech
 sp-std = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
 

--- a/frame/wormhole/issuing/s2s/Cargo.toml
+++ b/frame/wormhole/issuing/s2s/Cargo.toml
@@ -41,11 +41,11 @@ sp-std              = { default-features = false, git = "https://github.com/darw
 [dev-dependencies]
 # crates.io
 ethereum     = { version = "0.9", features = ["with-codec"] }
+evm          = { version = "0.30", features = ["with-codec"] }
 libsecp256k1 = { version = "0.5", features = ["static-context", "hmac"] }
 rlp          = { version = "0.5" }
 # darwinia-network
 darwinia-balances = { path = "../../../balances" }
-evm               = { features = ["with-codec"], version = "0.30" }
 pallet-timestamp  = { git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
 
 [features]

--- a/frame/wormhole/issuing/s2s/Cargo.toml
+++ b/frame/wormhole/issuing/s2s/Cargo.toml
@@ -45,7 +45,7 @@ libsecp256k1 = { version = "0.5", features = ["static-context", "hmac"] }
 rlp          = { version = "0.5" }
 # darwinia-network
 darwinia-balances = { path = "../../../balances" }
-evm               = { features = ["with-codec"], git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
+evm               = { features = ["with-codec"], version = "0.30" }
 pallet-timestamp  = { git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
 
 [features]

--- a/node/runtime/pangolin/Cargo.toml
+++ b/node/runtime/pangolin/Cargo.toml
@@ -52,7 +52,7 @@ drml-common-primitives                  = { default-features = false, path = "..
 dvm-ethereum                            = { default-features = false, path = "../../../frame/dvm" }
 dvm-rpc-runtime-api                     = { default-features = false, path = "../../../frame/dvm/rpc/runtime-api" }
 ethereum-primitives                     = { default-features = false, path = "../../../primitives/ethereum" }
-evm                                     = { default-features = false, features = ["with-codec"], git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
+evm                                     = { default-features = false, features = ["with-codec"], version = "0.30" }
 from-ethereum-issuing                   = { default-features = false, path = "../../../frame/wormhole/issuing/ethereum" }
 from-substrate-issuing                  = { default-features = false, path = "../../../frame/wormhole/issuing/s2s" }
 module-transaction-pause                = { default-features = false, path = "../../../frame/transaction-pause" }

--- a/node/runtime/pangolin/Cargo.toml
+++ b/node/runtime/pangolin/Cargo.toml
@@ -13,6 +13,7 @@ version    = "2.7.2"
 # crates.io
 array-bytes       = { version = "1.4" }
 codec             = { package = "parity-scale-codec", version = "2.1", default-features = false }
+evm               = { version = "0.30", default-features = false, features = ["with-codec"] }
 serde             = { version = "1.0", optional = true }
 smallvec          = { version = "1.7" }
 static_assertions = { version = "1.1" }
@@ -52,7 +53,6 @@ drml-common-primitives                  = { default-features = false, path = "..
 dvm-ethereum                            = { default-features = false, path = "../../../frame/dvm" }
 dvm-rpc-runtime-api                     = { default-features = false, path = "../../../frame/dvm/rpc/runtime-api" }
 ethereum-primitives                     = { default-features = false, path = "../../../primitives/ethereum" }
-evm                                     = { default-features = false, features = ["with-codec"], version = "0.30" }
 from-ethereum-issuing                   = { default-features = false, path = "../../../frame/wormhole/issuing/ethereum" }
 from-substrate-issuing                  = { default-features = false, path = "../../../frame/wormhole/issuing/s2s" }
 module-transaction-pause                = { default-features = false, path = "../../../frame/transaction-pause" }
@@ -133,6 +133,7 @@ default = ["std"]
 std = [
 	# crates.io
 	"codec/std",
+	"evm/std",
 	"serde",
 	# darwinia-network
 	"common-runtime/std",
@@ -170,7 +171,6 @@ std = [
 	"dvm-ethereum/std",
 	"dvm-rpc-runtime-api/std",
 	"ethereum-primitives/std",
-	"evm/std",
 	"from-ethereum-issuing/std",
 	"from-substrate-issuing/std",
 	"module-transaction-pause/std",

--- a/primitives/evm/Cargo.toml
+++ b/primitives/evm/Cargo.toml
@@ -15,7 +15,7 @@ codec                 = { package = "parity-scale-codec", version = "2.1", defau
 impl-trait-for-tuples = { version = "0.2" }
 serde                 = { version = "1.0", optional = true, features = ["derive"] }
 # darwinia-network
-evm = { default-features = false, features = ["with-codec"], git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
+evm = { default-features = false, features = ["with-codec"], version = "0.30" }
 # paritytech
 sp-core = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
 sp-std  = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }

--- a/primitives/evm/Cargo.toml
+++ b/primitives/evm/Cargo.toml
@@ -12,10 +12,9 @@ version     = "2.7.2"
 [dependencies]
 # crates.io
 codec                 = { package = "parity-scale-codec", version = "2.1", default-features = false }
+evm                   = { version = "0.30", default-features = false, features = ["with-codec"] }
 impl-trait-for-tuples = { version = "0.2" }
 serde                 = { version = "1.0", optional = true, features = ["derive"] }
-# darwinia-network
-evm = { default-features = false, features = ["with-codec"], version = "0.30" }
 # paritytech
 sp-core = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
 sp-std  = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
@@ -26,10 +25,9 @@ default = ["std"]
 std = [
 	# crates.io
 	"codec/std",
+	"evm/std",
 	"evm/with-serde",
 	"serde",
-	# darwinia-network
-	"evm/std",
 	# paritytech
 	"sp-core/std",
 	"sp-std/std",

--- a/primitives/evm/trace/events/Cargo.toml
+++ b/primitives/evm/trace/events/Cargo.toml
@@ -16,9 +16,9 @@ environmental  = { version = "1.1.2", default-features = false }
 ethereum       = { version = "0.9.0", default-features = false, features = ["with-codec"] }
 ethereum-types = { version = "0.12.0", default-features = false }
 # darwinia-network
-evm           = { default-features = false, features = ["with-codec", "tracing"], git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
-evm-gasometer = { default-features = false, features = ["tracing"], git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
-evm-runtime   = { default-features = false, features = ["tracing"], git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
+evm           = { default-features = false, features = ["with-codec"], version = "0.30" }
+evm-gasometer = { default-features = false, version = "0.30" }
+evm-runtime   = { default-features = false, version = "0.30" }
 # paritytech
 codec = { package = "parity-scale-codec", version = "2.2", default-features = false }
 

--- a/primitives/evm/trace/events/Cargo.toml
+++ b/primitives/evm/trace/events/Cargo.toml
@@ -15,10 +15,9 @@ version     = "2.7.1"
 environmental  = { version = "1.1.2", default-features = false }
 ethereum       = { version = "0.9.0", default-features = false, features = ["with-codec"] }
 ethereum-types = { version = "0.12.0", default-features = false }
-# darwinia-network
-evm           = { default-features = false, features = ["with-codec"], version = "0.30" }
-evm-gasometer = { default-features = false, version = "0.30" }
-evm-runtime   = { default-features = false, version = "0.30" }
+evm            = { version = "0.30", default-features = false, features = ["with-codec"] }
+evm-gasometer  = { version = "0.30", default-features = false }
+evm-runtime    = { version = "0.30", default-features = false }
 # paritytech
 codec = { package = "parity-scale-codec", version = "2.2", default-features = false }
 
@@ -31,7 +30,6 @@ std = [
 	"environmental/std",
 	"ethereum/std",
 	"ethereum-types/std",
-	# darwinia-network
 	"evm/std",
 	"evm-gasometer/std",
 	"evm-runtime/std",

--- a/primitives/evm/trace/tracer/Cargo.toml
+++ b/primitives/evm/trace/tracer/Cargo.toml
@@ -14,7 +14,7 @@ ethereum-types = { version = "0.12.0", default-features = false }
 # darwinia-network
 dp-evm-trace-events = { path = "../events", default-features = false, features = ["evm-tracing"] }
 dp-evm-trace-ext    = { path = "../ext", default-features = false }
-evm                 = { default-features = false, features = ["with-codec"], version = "0.30" }
+evm                 = { version = "0.30", default-features = false, features = ["with-codec"] }
 evm-gasometer       = { default-features = false, version = "0.30" }
 evm-runtime         = { default-features = false, version = "0.30" }
 # paritytech

--- a/primitives/evm/trace/tracer/Cargo.toml
+++ b/primitives/evm/trace/tracer/Cargo.toml
@@ -14,9 +14,9 @@ ethereum-types = { version = "0.12.0", default-features = false }
 # darwinia-network
 dp-evm-trace-events = { path = "../events", default-features = false, features = ["evm-tracing"] }
 dp-evm-trace-ext    = { path = "../ext", default-features = false }
-evm                 = { default-features = false, features = ["with-codec"], git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
-evm-gasometer       = { default-features = false, git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
-evm-runtime         = { default-features = false, git = "https://github.com/darwinia-network/evm", branch = "darwinia-v0.11.8" }
+evm                 = { default-features = false, features = ["with-codec"], version = "0.30" }
+evm-gasometer       = { default-features = false, version = "0.30" }
+evm-runtime         = { default-features = false, version = "0.30" }
 # paritytech
 codec      = { package = "parity-scale-codec", version = "2.2", default-features = false }
 sp-core    = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }

--- a/primitives/evm/trace/tracer/Cargo.toml
+++ b/primitives/evm/trace/tracer/Cargo.toml
@@ -11,12 +11,12 @@ version     = "2.7.1"
 [dependencies]
 # crates.io
 ethereum-types = { version = "0.12.0", default-features = false }
+evm            = { version = "0.30", default-features = false, features = ["with-codec"] }
+evm-gasometer  = { version = "0.30", default-features = false }
+evm-runtime    = { version = "0.30", default-features = false }
 # darwinia-network
 dp-evm-trace-events = { path = "../events", default-features = false, features = ["evm-tracing"] }
 dp-evm-trace-ext    = { path = "../ext", default-features = false }
-evm                 = { version = "0.30", default-features = false, features = ["with-codec"] }
-evm-gasometer       = { default-features = false, version = "0.30" }
-evm-runtime         = { default-features = false, version = "0.30" }
 # paritytech
 codec      = { package = "parity-scale-codec", version = "2.2", default-features = false }
 sp-core    = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.11.8" }
@@ -29,12 +29,12 @@ default = ["std"]
 std = [
 	# crates.io
 	"ethereum-types/std",
-	# darwinia-network
-	"dp-evm-trace-events/std",
-	"dp-evm-trace-ext/std",
 	"evm/std",
 	"evm-gasometer/std",
 	"evm-runtime/std",
+	# darwinia-network
+	"dp-evm-trace-events/std",
+	"dp-evm-trace-ext/std",
 	# paritytech
 	"codec/std",
 	"sp-core/std",


### PR DESCRIPTION
Use `[patch.crates-io]` to replace evm crates dep, this does not affect `evm-tracing`  feature compile. Much easier to maintain.