### PR TITLE
Add fee market slash event

### DIFF
--- a/frame/fee-market/src/lib.rs
+++ b/frame/fee-market/src/lib.rs
@@ -112,7 +112,7 @@ pub mod pallet {
 		UpdateCollateralSlashProtect(RingBalance<T>),
 		/// Update market assigned relayers numbers. \[new_assigned_relayers_number\]
 		UpdateAssignedRelayersNumber(u32),
-		/// Slash report \[order_lane, order_nonce, sent_time, confirm_time, delay_number, slash_amount\]
+		/// Slash report \[order_lane, order_nonce, sent_time, confirm_time, delay_number, account_id, slash_amount\]
 		FeeMarketSlash(
 			LaneId,
 			MessageNonce,

--- a/frame/fee-market/src/lib.rs
+++ b/frame/fee-market/src/lib.rs
@@ -96,6 +96,7 @@ pub mod pallet {
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	#[pallet::metadata(
 		T::AccountId = "AccountId",
+		T::BlockNumber = "BlockNumber",
 		RingBalance<T> = "RingBalance",
 	)]
 	pub enum Event<T: Config> {

--- a/frame/fee-market/src/lib.rs
+++ b/frame/fee-market/src/lib.rs
@@ -394,8 +394,8 @@ impl<T: Config> Pallet<T> {
 			relayer.collateral = new_collateral;
 		});
 
-		Self::deposit_event(<Event<T>>::FeeMarketSlash(report));
 		Self::update_market();
+		Self::deposit_event(<Event<T>>::FeeMarketSlash(report));
 	}
 
 	/// Remove enrolled relayer, then update market fee. (Update market needed)

--- a/frame/fee-market/src/s2s/mod.rs
+++ b/frame/fee-market/src/s2s/mod.rs
@@ -17,7 +17,7 @@
 // along with Darwinia. If not, see <https://www.gnu.org/licenses/>.
 
 pub mod payment;
-pub use payment::{FeeMarketPayment, SlashReport};
+pub use payment::FeeMarketPayment;
 
 pub mod callbacks;
 pub use callbacks::{FeeMarketMessageAcceptedHandler, FeeMarketMessageConfirmedHandler};

--- a/frame/fee-market/src/s2s/mod.rs
+++ b/frame/fee-market/src/s2s/mod.rs
@@ -17,7 +17,7 @@
 // along with Darwinia. If not, see <https://www.gnu.org/licenses/>.
 
 pub mod payment;
-pub use payment::FeeMarketPayment;
+pub use payment::{FeeMarketPayment, SlashReport};
 
 pub mod callbacks;
 pub use callbacks::{FeeMarketMessageAcceptedHandler, FeeMarketMessageConfirmedHandler};

--- a/frame/fee-market/src/s2s/payment.rs
+++ b/frame/fee-market/src/s2s/payment.rs
@@ -182,7 +182,7 @@ where
 
 					// Slash order's assigned relayers
 					let mut assigned_relayers_slash = RingBalance::<T>::zero();
-					let report = SlashReport::new(order.clone(), amount);
+					let report = SlashReport::new(&order, amount);
 					for assigned_relayer in order.relayers_slice() {
 						let slashed = do_slash::<T>(
 							&assigned_relayer.id,
@@ -305,7 +305,7 @@ pub struct SlashReport<T: Config> {
 
 impl<T: Config> SlashReport<T> {
 	pub fn new(
-		order: Order<T::AccountId, T::BlockNumber, RingBalance<T>>,
+		order: &Order<T::AccountId, T::BlockNumber, RingBalance<T>>,
 		amount: RingBalance<T>,
 	) -> Self {
 		Self {

--- a/frame/fee-market/src/tests.rs
+++ b/frame/fee-market/src/tests.rs
@@ -1100,6 +1100,69 @@ fn test_payment_slash_with_protect() {
 }
 
 #[test]
+fn test_payment_slash_event() {
+	new_test_ext().execute_with(|| {
+		// Send message
+		System::set_block_number(2);
+		let _ = FeeMarket::enroll_and_lock_collateral(Origin::signed(6), 400, Some(30));
+		let _ = FeeMarket::enroll_and_lock_collateral(Origin::signed(7), 400, Some(50));
+		let _ = FeeMarket::enroll_and_lock_collateral(Origin::signed(8), 400, Some(100));
+		assert_eq!(FeeMarket::relayer(&6).collateral, 400);
+		let market_fee = FeeMarket::market_fee().unwrap();
+		let (_, _) = send_regular_message(market_fee);
+		assert_ok!(FeeMarket::set_slash_protect(Origin::root(), 50));
+
+		// Receive delivery message proof
+		System::set_block_number(2000);
+		assert_ok!(Messages::receive_messages_delivery_proof(
+			Origin::signed(5),
+			TestMessagesDeliveryProof(Ok((
+				TEST_LANE_ID,
+				InboundLaneData {
+					relayers: vec![unrewarded_relayer(1, 1, TEST_RELAYER_A)]
+						.into_iter()
+						.collect(),
+					..Default::default()
+				}
+			))),
+			UnrewardedRelayersState {
+				unrewarded_relayer_entries: 1,
+				total_messages: 1,
+				..Default::default()
+			},
+		));
+
+		System::assert_has_event(Event::FeeMarket(crate::Event::FeeMarketSlash(
+			TEST_LANE_ID,
+			1,
+			2,
+			Some(2000),
+			Some(1848),
+			6,
+			50,
+		)));
+		System::assert_has_event(Event::FeeMarket(crate::Event::FeeMarketSlash(
+			TEST_LANE_ID,
+			1,
+			2,
+			Some(2000),
+			Some(1848),
+			7,
+			50,
+		)));
+		System::assert_has_event(Event::FeeMarket(crate::Event::FeeMarketSlash(
+			TEST_LANE_ID,
+			1,
+			2,
+			Some(2000),
+			Some(1848),
+			8,
+			50,
+		)));
+	});
+}
+
+#[test]
 fn test_payment_cal_slash_with_multiple_message() {
 	new_test_ext().execute_with(|| {
 		System::set_block_number(2);

--- a/frame/fee-market/src/tests.rs
+++ b/frame/fee-market/src/tests.rs
@@ -1133,31 +1133,37 @@ fn test_payment_slash_event() {
 		));
 
 		System::assert_has_event(Event::FeeMarket(crate::Event::FeeMarketSlash(
-			TEST_LANE_ID,
-			1,
-			2,
-			Some(2000),
-			Some(1848),
-			6,
-			50,
+			SlashReport {
+				lane: TEST_LANE_ID,
+				message: 1,
+				sent_time: 2,
+				confirm_time: Some(2000),
+				delay_time: Some(1848),
+				account_id: 6,
+				amount: 50,
+			},
 		)));
 		System::assert_has_event(Event::FeeMarket(crate::Event::FeeMarketSlash(
-			TEST_LANE_ID,
-			1,
-			2,
-			Some(2000),
-			Some(1848),
-			7,
-			50,
+			SlashReport {
+				lane: TEST_LANE_ID,
+				message: 1,
+				sent_time: 2,
+				confirm_time: Some(2000),
+				delay_time: Some(1848),
+				account_id: 7,
+				amount: 50,
+			},
 		)));
 		System::assert_has_event(Event::FeeMarket(crate::Event::FeeMarketSlash(
-			TEST_LANE_ID,
-			1,
-			2,
-			Some(2000),
-			Some(1848),
-			8,
-			50,
+			SlashReport {
+				lane: TEST_LANE_ID,
+				message: 1,
+				sent_time: 2,
+				confirm_time: Some(2000),
+				delay_time: Some(1848),
+				account_id: 8,
+				amount: 50,
+			},
 		)));
 	});
 }

--- a/node/runtime/pangolin/types.json
+++ b/node/runtime/pangolin/types.json
@@ -208,6 +208,15 @@
 		"fee": "Balance",
 		"valid_range": "BlockNumber"
 	},
+	"SlashReport": {
+		"lane": "LaneId",
+		"message": "MessageNonce",
+		"sent_time": "BlockNumber",
+		"confirm_time": "BlockNumber",
+		"delay_time": "BlockNumber",
+		"account_id": "AccountId",
+		"amount": "Balance"
+	},
 	"AddressT": "[u8; 20; AddressT]",
 	"__[pallet.header-mmr]__": null,
 	"NodeIndex": "u64",

--- a/primitives/fee-market/src/lib.rs
+++ b/primitives/fee-market/src/lib.rs
@@ -213,6 +213,42 @@ where
 	}
 }
 
+/// The detail information about slash behavior
+#[derive(Clone, Encode, Decode, Eq, PartialEq, Debug)]
+pub struct SlashReport<AccountId, BlockNumber, Balance> {
+	pub lane: LaneId,
+	pub message: MessageNonce,
+	pub sent_time: BlockNumber,
+	pub confirm_time: Option<BlockNumber>,
+	pub delay_time: Option<BlockNumber>,
+	pub account_id: AccountId,
+	pub amount: Balance,
+}
+
+impl<AccountId, BlockNumber, Balance> SlashReport<AccountId, BlockNumber, Balance>
+where
+	BlockNumber:
+		Add<Output = BlockNumber> + Copy + AddAssign + PartialOrd + Sub<Output = BlockNumber>,
+	Balance: Copy + PartialOrd + Default,
+	AccountId: Clone + PartialEq,
+{
+	pub fn new(
+		order: &Order<AccountId, BlockNumber, Balance>,
+		account_id: AccountId,
+		amount: Balance,
+	) -> Self {
+		Self {
+			lane: order.lane,
+			message: order.message,
+			sent_time: order.sent_time,
+			confirm_time: order.confirm_time,
+			delay_time: order.delivery_delay(),
+			account_id,
+			amount,
+		}
+	}
+}
+
 #[cfg(test)]
 mod test {
 	use super::*;


### PR DESCRIPTION
Close #1009 

After discussing with Yalin, both s2s message and fee market pallets will clean the old order/message data as time goes by. So it is better to keep all these fields about the order status. 