### PR TITLE
Use `decimal_convert` to refactor AccountBasic tests

### DIFF
--- a/frame/dvm/src/account_basic.rs
+++ b/frame/dvm/src/account_basic.rs
@@ -142,7 +142,6 @@ where
 		let target_account = Self::account_basic(target);
 		let new_target_balance = target_account.balance.saturating_add(value);
 		Self::mutate_account_basic_balance(target, new_target_balance);
-
 		Ok(())
 	}
 
@@ -224,16 +223,14 @@ where
 		}
 
 		// Handle existential deposit.
-		let ring_existential_deposit: u128 =
-			<T as Config>::RingCurrency::minimum_balance().saturated_into::<u128>();
-		let kton_existential_deposit: u128 =
-			<T as Config>::KtonCurrency::minimum_balance().saturated_into::<u128>();
-		let ring_existential_deposit = U256::from(ring_existential_deposit) * helper;
-		let kton_existential_deposit = U256::from(kton_existential_deposit) * helper;
+		let ring_min = <T as Config>::RingCurrency::minimum_balance().saturated_into::<u128>();
+		let kton_min = <T as Config>::KtonCurrency::minimum_balance().saturated_into::<u128>();
+		let ring_ed = decimal_convert(ring_min, None);
+		let kton_ed = decimal_convert(kton_min, None);
 
 		let ring_account = T::RingAccountBasic::account_balance(&account_id);
 		let kton_account = T::KtonAccountBasic::account_balance(&account_id);
-		if ring_account < ring_existential_deposit && kton_account < kton_existential_deposit {
+		if ring_account < ring_ed && kton_account < kton_ed {
 			<RingRemainBalance as RemainBalanceOp<T, RingBalance<T>>>::remove_remaining_balance(
 				&account_id,
 			);

--- a/frame/support/src/evm.rs
+++ b/frame/support/src/evm.rs
@@ -151,12 +151,11 @@ impl DVMTransaction {
 	}
 }
 
-pub fn decimal_convert(v: u128, p: Option<u128>) -> U256 {
-	if let Some(p) = p {
-		return U256::from(v)
+pub fn decimal_convert(main_balance: u128, remaining_balance: Option<u128>) -> U256 {
+	if let Some(rb) = remaining_balance {
+		return U256::from(main_balance)
 			.saturating_mul(U256::from(POW_9))
-			.saturating_add(U256::from(p));
+			.saturating_add(U256::from(rb));
 	}
-	U256::from(v).saturating_mul(U256::from(POW_9))
+	U256::from(main_balance).saturating_mul(U256::from(POW_9))
 }
-

--- a/frame/support/src/evm.rs
+++ b/frame/support/src/evm.rs
@@ -151,6 +151,7 @@ impl DVMTransaction {
 	}
 }
 
+/// Decimal conversion from RING/KTON to Ethereum decimal format.
 pub fn decimal_convert(main_balance: u128, remaining_balance: Option<u128>) -> U256 {
 	if let Some(rb) = remaining_balance {
 		return U256::from(main_balance)

--- a/frame/support/src/evm.rs
+++ b/frame/support/src/evm.rs
@@ -150,3 +150,13 @@ impl DVMTransaction {
 		}
 	}
 }
+
+pub fn decimal_convert(v: u128, p: Option<u128>) -> U256 {
+	if let Some(p) = p {
+		return U256::from(v)
+			.saturating_mul(U256::from(POW_9))
+			.saturating_add(U256::from(p));
+	}
+	U256::from(v).saturating_mul(U256::from(POW_9))
+}
+


### PR DESCRIPTION
No logic changes. Just some refactor works to make the `account_basic` tests easy to maintain.