### PR TITLE
DVM signed transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1530,7 +1530,7 @@ dependencies = [
  "evm",
  "evm-gasometer",
  "evm-runtime",
- "fp-evm",
+ "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -1557,7 +1557,7 @@ dependencies = [
  "dp-contract",
  "ethereum-primitives",
  "evm",
- "fp-evm",
+ "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.0)",
  "sp-std",
 ]
 
@@ -1568,7 +1568,7 @@ dependencies = [
  "darwinia-evm",
  "darwinia-evm-precompile-utils",
  "evm",
- "fp-evm",
+ "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
  "from-ethereum-issuing",
  "parity-scale-codec",
  "sp-core",
@@ -1588,7 +1588,7 @@ dependencies = [
  "dp-contract",
  "dp-s2s",
  "evm",
- "fp-evm",
+ "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
  "frame-support",
  "from-substrate-issuing",
  "log",
@@ -1605,7 +1605,7 @@ dependencies = [
  "darwinia-evm",
  "darwinia-support",
  "evm",
- "fp-evm",
+ "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
  "frame-support",
  "parity-scale-codec",
  "sp-core",
@@ -1622,7 +1622,7 @@ dependencies = [
  "ethabi",
  "ethereum-types",
  "evm",
- "fp-evm",
+ "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
  "frame-support",
  "frame-system",
  "log",
@@ -1927,7 +1927,7 @@ name = "dc-db"
 version = "2.7.2"
 dependencies = [
  "dvm-ethereum",
- "fp-evm",
+ "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
  "fp-storage",
  "kvdb",
  "kvdb-rocksdb",
@@ -1970,7 +1970,7 @@ dependencies = [
  "ethereum",
  "ethereum-types",
  "evm",
- "fc-rpc-core",
+ "fc-rpc-core 1.1.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
  "fp-storage",
  "futures 0.3.19",
  "jsonrpc-core",
@@ -2296,7 +2296,7 @@ dependencies = [
  "drml-common-primitives",
  "dvm-ethereum",
  "dvm-rpc-runtime-api",
- "fc-rpc-core",
+ "fc-rpc-core 1.1.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
  "futures 0.3.19",
  "jsonrpc-core",
  "jsonrpc-pubsub",
@@ -2347,7 +2347,7 @@ dependencies = [
  "drml-common-primitives",
  "drml-rpc",
  "dvm-rpc-runtime-api",
- "fc-rpc-core",
+ "fc-rpc-core 1.1.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
  "frame-benchmarking",
  "frame-system-rpc-runtime-api",
  "futures 0.3.19",
@@ -2415,7 +2415,7 @@ dependencies = [
  "ethereum",
  "ethereum-types",
  "evm",
- "fp-evm",
+ "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
  "fp-storage",
  "frame-support",
  "frame-system",
@@ -2443,8 +2443,8 @@ dependencies = [
  "dp-evm-trace-rpc",
  "ethereum",
  "ethereum-types",
- "fc-rpc-core",
- "fp-evm",
+ "fc-rpc-core 1.1.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.0)",
+ "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.0)",
  "futures 0.3.19",
  "jsonrpc-core",
  "jsonrpc-derive",
@@ -2464,7 +2464,7 @@ version = "2.7.2"
 dependencies = [
  "ethereum",
  "ethereum-types",
- "fp-evm",
+ "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
  "parity-scale-codec",
  "scale-info",
  "sp-api",
@@ -2829,6 +2829,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "fc-rpc-core"
+version = "1.1.0-dev"
+source = "git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1#a049818ea9b24447b5a871b8007c5c22b69d1a46"
+dependencies = [
+ "ethereum-types",
+ "jsonrpc-core",
+ "jsonrpc-core-client",
+ "jsonrpc-derive",
+ "jsonrpc-pubsub",
+ "rustc-hex",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "fdlimit"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2932,9 +2947,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "fp-evm"
+version = "3.0.0-dev"
+source = "git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1#a049818ea9b24447b5a871b8007c5c22b69d1a46"
+dependencies = [
+ "evm",
+ "impl-trait-for-tuples 0.1.3",
+ "parity-scale-codec",
+ "serde",
+ "sp-core",
+ "sp-std",
+]
+
+[[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.0#ae3f01905e4138f2d07919adede0b0b195d1827f"
+source = "git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1#a049818ea9b24447b5a871b8007c5c22b69d1a46"
 
 [[package]]
 name = "frame-benchmarking"
@@ -3149,7 +3177,7 @@ dependencies = [
  "dp-contract",
  "dvm-ethereum",
  "ethereum-primitives",
- "fp-evm",
+ "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -3179,7 +3207,7 @@ dependencies = [
  "ethereum-primitives",
  "ethereum-types",
  "evm",
- "fp-evm",
+ "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -5682,10 +5710,9 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.0#ae3f01905e4138f2d07919adede0b0b195d1827f"
+source = "git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1#a049818ea9b24447b5a871b8007c5c22b69d1a46"
 dependencies = [
- "evm",
- "fp-evm",
+ "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
  "num",
  "sp-core",
  "sp-io",
@@ -5694,10 +5721,9 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.0#ae3f01905e4138f2d07919adede0b0b195d1827f"
+source = "git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1#a049818ea9b24447b5a871b8007c5c22b69d1a46"
 dependencies = [
- "evm",
- "fp-evm",
+ "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
  "sp-core",
  "sp-io",
  "tiny-keccak",
@@ -5706,10 +5732,9 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.0#ae3f01905e4138f2d07919adede0b0b195d1827f"
+source = "git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1#a049818ea9b24447b5a871b8007c5c22b69d1a46"
 dependencies = [
- "evm",
- "fp-evm",
+ "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
  "ripemd160",
  "sp-core",
  "sp-io",
@@ -6087,7 +6112,7 @@ dependencies = [
  "dvm-rpc-runtime-api",
  "ethereum-primitives",
  "evm",
- "fp-evm",
+ "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-executive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-evm-precompile-bridge-bsc"
-version = "2.7.1"
+version = "2.7.2"
 dependencies = [
  "darwinia-bridge-bsc",
  "darwinia-evm-precompile-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1530,7 +1530,7 @@ dependencies = [
  "evm",
  "evm-gasometer",
  "evm-runtime",
- "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
+ "fp-evm",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -1557,7 +1557,7 @@ dependencies = [
  "dp-contract",
  "ethereum-primitives",
  "evm",
- "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.0)",
+ "fp-evm",
  "sp-std",
 ]
 
@@ -1568,7 +1568,7 @@ dependencies = [
  "darwinia-evm",
  "darwinia-evm-precompile-utils",
  "evm",
- "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
+ "fp-evm",
  "from-ethereum-issuing",
  "parity-scale-codec",
  "sp-core",
@@ -1588,7 +1588,7 @@ dependencies = [
  "dp-contract",
  "dp-s2s",
  "evm",
- "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
+ "fp-evm",
  "frame-support",
  "from-substrate-issuing",
  "log",
@@ -1605,7 +1605,7 @@ dependencies = [
  "darwinia-evm",
  "darwinia-support",
  "evm",
- "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
+ "fp-evm",
  "frame-support",
  "parity-scale-codec",
  "sp-core",
@@ -1622,7 +1622,7 @@ dependencies = [
  "ethabi",
  "ethereum-types",
  "evm",
- "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
+ "fp-evm",
  "frame-support",
  "frame-system",
  "log",
@@ -1927,7 +1927,7 @@ name = "dc-db"
 version = "2.7.2"
 dependencies = [
  "dvm-ethereum",
- "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
+ "fp-evm",
  "fp-storage",
  "kvdb",
  "kvdb-rocksdb",
@@ -1970,7 +1970,7 @@ dependencies = [
  "ethereum 0.10.0",
  "ethereum-types",
  "evm",
- "fc-rpc-core 1.1.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
+ "fc-rpc-core",
  "fp-storage",
  "futures 0.3.19",
  "jsonrpc-core",
@@ -2296,7 +2296,7 @@ dependencies = [
  "drml-common-primitives",
  "dvm-ethereum",
  "dvm-rpc-runtime-api",
- "fc-rpc-core 1.1.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
+ "fc-rpc-core",
  "futures 0.3.19",
  "jsonrpc-core",
  "jsonrpc-pubsub",
@@ -2347,7 +2347,7 @@ dependencies = [
  "drml-common-primitives",
  "drml-rpc",
  "dvm-rpc-runtime-api",
- "fc-rpc-core 1.1.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
+ "fc-rpc-core",
  "frame-benchmarking",
  "frame-system-rpc-runtime-api",
  "futures 0.3.19",
@@ -2415,7 +2415,7 @@ dependencies = [
  "ethereum 0.10.0",
  "ethereum-types",
  "evm",
- "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
+ "fp-evm",
  "fp-self-contained",
  "fp-storage",
  "frame-support",
@@ -2444,8 +2444,8 @@ dependencies = [
  "dp-evm-trace-rpc",
  "ethereum 0.10.0",
  "ethereum-types",
- "fc-rpc-core 1.1.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.0)",
- "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.0)",
+ "fc-rpc-core",
+ "fp-evm",
  "futures 0.3.19",
  "jsonrpc-core",
  "jsonrpc-derive",
@@ -2465,7 +2465,7 @@ version = "2.7.2"
 dependencies = [
  "ethereum 0.10.0",
  "ethereum-types",
- "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
+ "fp-evm",
  "parity-scale-codec",
  "scale-info",
  "sp-api",
@@ -2835,21 +2835,6 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.0#ae3f01905e4138f2d07919adede0b0b195d1827f"
-dependencies = [
- "ethereum-types",
- "jsonrpc-core",
- "jsonrpc-core-client",
- "jsonrpc-derive",
- "jsonrpc-pubsub",
- "rustc-hex",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "fc-rpc-core"
-version = "1.1.0-dev"
 source = "git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1#a049818ea9b24447b5a871b8007c5c22b69d1a46"
 dependencies = [
  "ethereum-types",
@@ -2950,19 +2935,6 @@ checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding 2.1.0",
-]
-
-[[package]]
-name = "fp-evm"
-version = "3.0.0-dev"
-source = "git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.0#ae3f01905e4138f2d07919adede0b0b195d1827f"
-dependencies = [
- "evm",
- "impl-trait-for-tuples 0.1.3",
- "parity-scale-codec",
- "serde",
- "sp-core",
- "sp-std",
 ]
 
 [[package]]
@@ -3213,7 +3185,7 @@ dependencies = [
  "dp-contract",
  "dvm-ethereum",
  "ethereum-primitives",
- "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
+ "fp-evm",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -3243,7 +3215,7 @@ dependencies = [
  "ethereum-primitives",
  "ethereum-types",
  "evm",
- "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
+ "fp-evm",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -5748,7 +5720,7 @@ name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
 source = "git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1#a049818ea9b24447b5a871b8007c5c22b69d1a46"
 dependencies = [
- "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
+ "fp-evm",
  "num",
  "sp-core",
  "sp-io",
@@ -5759,7 +5731,7 @@ name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
 source = "git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1#a049818ea9b24447b5a871b8007c5c22b69d1a46"
 dependencies = [
- "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
+ "fp-evm",
  "sp-core",
  "sp-io",
  "tiny-keccak",
@@ -5770,7 +5742,7 @@ name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
 source = "git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1#a049818ea9b24447b5a871b8007c5c22b69d1a46"
 dependencies = [
- "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
+ "fp-evm",
  "ripemd160",
  "sp-core",
  "sp-io",
@@ -6148,7 +6120,7 @@ dependencies = [
  "dvm-rpc-runtime-api",
  "ethereum-primitives",
  "evm",
- "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
+ "fp-evm",
  "fp-self-contained",
  "frame-benchmarking",
  "frame-election-provider-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1864,7 +1864,7 @@ version = "2.7.2"
 dependencies = [
  "bp-messages",
  "bp-runtime",
- "ethereum",
+ "ethereum 0.10.0",
  "ethereum-primitives",
  "frame-support",
  "frame-system",
@@ -1967,7 +1967,7 @@ dependencies = [
  "dvm-ethereum",
  "dvm-rpc-core",
  "dvm-rpc-runtime-api",
- "ethereum",
+ "ethereum 0.10.0",
  "ethereum-types",
  "evm",
  "fc-rpc-core 1.1.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
@@ -2120,7 +2120,7 @@ dependencies = [
 name = "dp-consensus"
 version = "2.7.2"
 dependencies = [
- "ethereum",
+ "ethereum 0.10.0",
  "parity-scale-codec",
  "rlp",
  "sha3 0.9.1",
@@ -2147,7 +2147,7 @@ name = "dp-evm-trace-apis"
 version = "2.7.2"
 dependencies = [
  "environmental",
- "ethereum",
+ "ethereum 0.10.0",
  "ethereum-types",
  "hex",
  "parity-scale-codec",
@@ -2165,7 +2165,7 @@ name = "dp-evm-trace-events"
 version = "2.7.2"
 dependencies = [
  "environmental",
- "ethereum",
+ "ethereum 0.10.0",
  "ethereum-types",
  "evm",
  "evm-gasometer",
@@ -2412,10 +2412,11 @@ dependencies = [
  "dp-consensus",
  "dvm-rpc-runtime-api",
  "ethabi",
- "ethereum",
+ "ethereum 0.10.0",
  "ethereum-types",
  "evm",
  "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
+ "fp-self-contained",
  "fp-storage",
  "frame-support",
  "frame-system",
@@ -2441,7 +2442,7 @@ dependencies = [
  "darwinia-evm",
  "dc-tracer",
  "dp-evm-trace-rpc",
- "ethereum",
+ "ethereum 0.10.0",
  "ethereum-types",
  "fc-rpc-core 1.1.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.0)",
  "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.0)",
@@ -2462,7 +2463,7 @@ dependencies = [
 name = "dvm-rpc-runtime-api"
 version = "2.7.2"
 dependencies = [
- "ethereum",
+ "ethereum 0.10.0",
  "ethereum-types",
  "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
  "parity-scale-codec",
@@ -2668,6 +2669,24 @@ dependencies = [
 
 [[package]]
 name = "ethereum"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a67be3eaf296ef668733f54c637e84d0ca34eaf194f0077455135981ad464c3"
+dependencies = [
+ "bytes 1.1.0",
+ "ethereum-types",
+ "hash-db",
+ "hash256-std-hasher",
+ "parity-scale-codec",
+ "rlp",
+ "rlp-derive",
+ "serde",
+ "sha3 0.9.1",
+ "triehash",
+]
+
+[[package]]
+name = "ethereum"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fb916554a4dba293ea69c69ad5653e21d770a9d0c2496b5fa0a1f5a3946d87"
@@ -2736,7 +2755,7 @@ source = "git+https://github.com/darwinia-network/evm?branch=darwinia-v0.12.0#09
 dependencies = [
  "auto_impl",
  "environmental",
- "ethereum",
+ "ethereum 0.10.0",
  "evm-core",
  "evm-gasometer",
  "evm-runtime",
@@ -2957,6 +2976,23 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-std",
+]
+
+[[package]]
+name = "fp-self-contained"
+version = "1.0.0-dev"
+source = "git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1#a049818ea9b24447b5a871b8007c5c22b69d1a46"
+dependencies = [
+ "ethereum 0.9.0",
+ "frame-support",
+ "parity-scale-codec",
+ "parity-util-mem",
+ "scale-info",
+ "serde",
+ "sha3 0.8.2",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -3203,7 +3239,7 @@ dependencies = [
  "dp-contract",
  "dp-s2s",
  "dvm-ethereum",
- "ethereum",
+ "ethereum 0.10.0",
  "ethereum-primitives",
  "ethereum-types",
  "evm",
@@ -6113,6 +6149,7 @@ dependencies = [
  "ethereum-primitives",
  "evm",
  "fp-evm 3.0.0-dev (git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.1)",
+ "fp-self-contained",
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-executive",
@@ -6327,8 +6364,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f4cb4e169446179cbc6b8b6320cc9fca49bd2e94e8db25f25f200a8ea774770"
 dependencies = [
  "cfg-if 1.0.0",
+ "ethereum-types",
  "hashbrown",
  "impl-trait-for-tuples 0.2.1",
+ "lru",
  "parity-util-mem-derive",
  "parking_lot 0.11.2",
  "primitive-types",
@@ -9702,6 +9741,7 @@ dependencies = [
  "drml-common-primitives",
  "dvm-ethereum",
  "dvm-rpc-runtime-api",
+ "fp-self-contained",
  "frame-executive",
  "frame-support",
  "frame-system",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3216,6 +3216,7 @@ dependencies = [
  "ethereum-types",
  "evm",
  "fp-evm",
+ "fp-self-contained",
  "frame-benchmarking",
  "frame-support",
  "frame-system",

--- a/client/dvm/db/Cargo.toml
+++ b/client/dvm/db/Cargo.toml
@@ -22,5 +22,5 @@ sp-core     = { git = "https://github.com/darwinia-network/substrate", branch = 
 sp-database = { git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 sp-runtime  = { git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 # frontier
-fp-evm     = { git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.0" }
-fp-storage = { git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.0" }
+fp-evm     = { git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
+fp-storage = { git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }

--- a/client/dvm/rpc/Cargo.toml
+++ b/client/dvm/rpc/Cargo.toml
@@ -54,8 +54,8 @@ sp-io                   = { git = "https://github.com/darwinia-network/substrate
 sp-runtime              = { git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 sp-storage              = { git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 # frontier
-fc-rpc-core = { git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.0" }
-fp-storage  = { git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.0" }
+fc-rpc-core = { git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
+fp-storage  = { git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
 
 [features]
 rpc_binary_search_estimate = []

--- a/frame/dvm/Cargo.toml
+++ b/frame/dvm/Cargo.toml
@@ -34,8 +34,9 @@ sp-io            = { default-features = false, git = "https://github.com/darwini
 sp-runtime       = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 sp-std           = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 # frontier
-fp-evm     = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
-fp-storage = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
+fp-evm            = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
+fp-self-contained = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
+fp-storage        = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
 
 [dev-dependencies]
 # crates.io
@@ -76,6 +77,7 @@ std = [
 	"sp-std/std",
 	# frontier
 	"fp-evm/std",
+	"fp-self-contained/std",
 	"fp-storage/std",
 ]
 

--- a/frame/dvm/Cargo.toml
+++ b/frame/dvm/Cargo.toml
@@ -34,8 +34,8 @@ sp-io            = { default-features = false, git = "https://github.com/darwini
 sp-runtime       = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 sp-std           = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 # frontier
-fp-evm     = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.0" }
-fp-storage = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.0" }
+fp-evm     = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
+fp-storage = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
 
 [dev-dependencies]
 # crates.io
@@ -46,7 +46,7 @@ libsecp256k1 = { version = "0.5", features = ["static-context", "hmac"] }
 darwinia-balances                = { path = "../balances" }
 darwinia-evm-precompile-transfer = { path = "../evm/precompile/contracts/transfer" }
 # frontier
-pallet-evm-precompile-simple = { git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.0" }
+pallet-evm-precompile-simple = { git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
 
 [features]
 default = ["std"]

--- a/frame/dvm/rpc/Cargo.toml
+++ b/frame/dvm/rpc/Cargo.toml
@@ -1,4 +1,4 @@
-[package]
+	[package]
 authors     = ["Darwinia Network <hello@darwinia.network>"]
 description = "Runtime primitives for Ethereum RPC (web3) compatibility layer for Darwinia."
 edition     = "2021"

--- a/frame/dvm/rpc/Cargo.toml
+++ b/frame/dvm/rpc/Cargo.toml
@@ -1,4 +1,4 @@
-	[package]
+[package]
 authors     = ["Darwinia Network <hello@darwinia.network>"]
 description = "Runtime primitives for Ethereum RPC (web3) compatibility layer for Darwinia."
 edition     = "2021"
@@ -31,5 +31,5 @@ sp-core    = { git = "https://github.com/darwinia-network/substrate", branch = "
 sp-runtime = { git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 sp-std     = { git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 # frontier
-fc-rpc-core = { git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.0" }
-fp-evm      = { git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.0" }
+fc-rpc-core = { git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
+fp-evm      = { git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }

--- a/frame/dvm/rpc/runtime-api/Cargo.toml
+++ b/frame/dvm/rpc/runtime-api/Cargo.toml
@@ -22,7 +22,7 @@ sp-io      = { default-features = false, git = "https://github.com/darwinia-netw
 sp-runtime = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 sp-std     = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 # frontier
-fp-evm = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.0" }
+fp-evm = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
 
 [features]
 default = ["std"]

--- a/frame/dvm/src/lib.rs
+++ b/frame/dvm/src/lib.rs
@@ -233,9 +233,6 @@ pub mod pallet {
 					Self::apply_validated_transaction(source, transaction).expect(
 						"pre-block transaction execution failed; the block cannot be built",
 					);
-					// Self::rpc_transact(source, transaction).expect(
-					// 	"pre-block transaction verification failed; the block cannot be built",
-					// );
 				}
 			}
 			0
@@ -254,7 +251,6 @@ pub mod pallet {
 			transaction: TransactionV0,
 		) -> DispatchResultWithPostInfo {
 			let source = ensure_ethereum_transaction(origin)?;
-			// Self::rpc_transact(source, transaction)
 			Self::apply_validated_transaction(source, transaction)
 		}
 
@@ -395,9 +391,7 @@ impl<T: Config> Pallet<T> {
 			.into());
 		}
 
-		// let account_data = pallet_evm::Pallet::<T>::account_basic(&origin);
 		let account_data = <T as darwinia_evm::Config>::RingAccountBasic::account_basic(&origin);
-
 		let fee = transaction.gas_price.saturating_mul(transaction.gas_limit);
 		let total_payment = transaction.value.saturating_add(fee);
 		if account_data.balance < total_payment {
@@ -405,7 +399,6 @@ impl<T: Config> Pallet<T> {
 		}
 
 		let min_gas_price = T::FeeCalculator::min_gas_price();
-
 		if transaction.gas_price < min_gas_price {
 			return Err(InvalidTransaction::Payment.into());
 		}
@@ -421,7 +414,6 @@ impl<T: Config> Pallet<T> {
 		transaction: &TransactionV0,
 	) -> TransactionValidity {
 		let account_nonce = Self::validate_transaction_common(origin, transaction)?;
-
 		if transaction.nonce < account_nonce {
 			return Err(InvalidTransaction::Stale.into());
 		}
@@ -465,10 +457,9 @@ impl<T: Config> Pallet<T> {
 		}
 	}
 
-	/// Execute transaction from EthApi(network transaction)
+	/// Execute transaction from EthApi or PreLog Block
 	/// NOTE: For the rpc transaction, the execution will return ok(..) even when encounters error
-	/// from evm runner
-	// fn rpc_transact(source: H160, transaction: TransactionV0) -> DispatchResultWithPostInfo {
+	/// 	  from evm runner
 	fn apply_validated_transaction(
 		source: H160,
 		transaction: TransactionV0,

--- a/frame/dvm/src/mock.rs
+++ b/frame/dvm/src/mock.rs
@@ -19,7 +19,7 @@
 //! Test utilities
 
 // --- crates.io ---
-use codec::{Decode, Encode, MaxEncodedLen, WrapperTypeDecode, WrapperTypeEncode};
+use codec::{Decode, Encode, MaxEncodedLen};
 use ethereum::{TransactionAction, TransactionSignature};
 use evm::{executor::PrecompileOutput, Context, ExitError};
 use rlp::RlpStream;
@@ -35,7 +35,7 @@ use pallet_evm_precompile_simple::{ECRecover, Identity, Ripemd160, Sha256};
 use sp_core::{H160, H256, U256};
 use sp_runtime::{
 	testing::Header,
-	traits::{BlakeTwo256, IdentityLookup, SignedExtension},
+	traits::{BlakeTwo256, IdentityLookup},
 	AccountId32, Perbill, RuntimeDebug,
 };
 use sp_std::prelude::*;

--- a/frame/dvm/src/mock.rs
+++ b/frame/dvm/src/mock.rs
@@ -19,7 +19,7 @@
 //! Test utilities
 
 // --- crates.io ---
-use codec::{Decode, Encode, MaxEncodedLen};
+use codec::{Decode, Encode, MaxEncodedLen, WrapperTypeDecode, WrapperTypeEncode};
 use ethereum::{TransactionAction, TransactionSignature};
 use evm::{executor::PrecompileOutput, Context, ExitError};
 use rlp::RlpStream;
@@ -35,7 +35,7 @@ use pallet_evm_precompile_simple::{ECRecover, Identity, Ripemd160, Sha256};
 use sp_core::{H160, H256, U256};
 use sp_runtime::{
 	testing::Header,
-	traits::{BlakeTwo256, IdentityLookup},
+	traits::{BlakeTwo256, IdentityLookup, SignedExtension},
 	AccountId32, Perbill, RuntimeDebug,
 };
 use sp_std::prelude::*;
@@ -46,7 +46,8 @@ use darwinia_evm_precompile_transfer::Transfer;
 use darwinia_support::evm::IntoAccountId;
 
 type Block = MockBlock<Test>;
-type UncheckedExtrinsic = MockUncheckedExtrinsic<Test>;
+pub type SignedExtra = (frame_system::CheckSpecVersion<Test>,);
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test, (), SignedExtra>;
 type Balance = u64;
 
 darwinia_support::impl_test_account_data! {}
@@ -227,6 +228,54 @@ frame_support::construct_runtime! {
 	}
 }
 
+impl fp_self_contained::SelfContainedCall for Call {
+	type SignedInfo = H160;
+
+	fn is_self_contained(&self) -> bool {
+		match self {
+			Call::Ethereum(call) => call.is_self_contained(),
+			_ => false,
+		}
+	}
+
+	fn check_self_contained(&self) -> Option<Result<Self::SignedInfo, TransactionValidityError>> {
+		match self {
+			Call::Ethereum(call) => call.check_self_contained(),
+			_ => None,
+		}
+	}
+
+	fn validate_self_contained(&self, info: &Self::SignedInfo) -> Option<TransactionValidity> {
+		match self {
+			Call::Ethereum(call) => call.validate_self_contained(info),
+			_ => None,
+		}
+	}
+
+	fn pre_dispatch_self_contained(
+		&self,
+		info: &Self::SignedInfo,
+	) -> Option<Result<(), TransactionValidityError>> {
+		match self {
+			Call::Ethereum(call) => call.pre_dispatch_self_contained(info),
+			_ => None,
+		}
+	}
+
+	fn apply_self_contained(
+		self,
+		info: Self::SignedInfo,
+	) -> Option<sp_runtime::DispatchResultWithInfo<sp_runtime::traits::PostDispatchInfoOf<Self>>> {
+		use sp_runtime::traits::Dispatchable as _;
+		match self {
+			call @ Call::Ethereum(crate::Call::transact { .. }) => {
+				Some(call.dispatch(Origin::from(crate::RawOrigin::EthereumTransaction(info))))
+			}
+			_ => None,
+		}
+	}
+}
+
 pub struct AccountInfo {
 	pub address: H160,
 	pub account_id: AccountId32,
@@ -262,6 +311,10 @@ impl UnsignedTransaction {
 	}
 
 	pub fn sign(&self, key: &H256) -> TransactionV0 {
+		self.sign_with_chain_id(key, ChainId::get())
+	}
+
+	pub fn sign_with_chain_id(&self, key: &H256, chain_id: u64) -> TransactionV0 {
 		let hash = self.signing_hash();
 		let msg = libsecp256k1::Message::parse(hash.as_fixed_bytes());
 		let s = libsecp256k1::sign(
@@ -271,7 +324,7 @@ impl UnsignedTransaction {
 		let sig = s.0.serialize();
 
 		let sig = TransactionSignature::new(
-			s.1.serialize() as u64 % 2 + ChainId::get() * 2 + 35,
+			s.1.serialize() as u64 % 2 + chain_id * 2 + 35,
 			H256::from_slice(&sig[0..32]),
 			H256::from_slice(&sig[32..64]),
 		)

--- a/frame/dvm/src/mock.rs
+++ b/frame/dvm/src/mock.rs
@@ -223,7 +223,7 @@ frame_support::construct_runtime! {
 		Ring: darwinia_balances::<Instance1>::{Pallet, Call, Storage, Config<T>, Event<T>},
 		Kton: darwinia_balances::<Instance2>::{Pallet, Call, Storage, Config<T>, Event<T>},
 		EVM: darwinia_evm::{Pallet, Call, Storage, Config, Event<T>},
-		Ethereum: dvm_ethereum::{Pallet, Call, Storage, Config, Event},
+		Ethereum: dvm_ethereum::{Pallet, Call, Storage, Config, Event, Origin},
 	}
 }
 

--- a/frame/dvm/src/tests.rs
+++ b/frame/dvm/src/tests.rs
@@ -20,7 +20,7 @@
 use array_bytes::{bytes2hex, hex2bytes_unchecked};
 use codec::Decode;
 use ethabi::{Function, Param, ParamType, StateMutability, Token};
-use ethereum::{TransactionAction, TransactionSignature, TransactionV0};
+use ethereum::{TransactionAction, TransactionV0};
 use evm::{ExitReason, ExitSucceed};
 use std::str::FromStr;
 // --- darwinia-network ---
@@ -33,10 +33,10 @@ use crate::{
 use darwinia_evm::AccountBasic;
 use darwinia_support::evm::{decimal_convert, IntoAccountId, IntoH160, TRANSFER_ADDR};
 // --- paritytech ---
-use frame_support::{assert_err, assert_noop, assert_ok, unsigned::ValidateUnsigned};
+use frame_support::{assert_err, assert_noop, assert_ok, weights::GetDispatchInfo as _};
 use sp_runtime::{
 	traits::Applyable,
-	transaction_validity::{InvalidTransaction, TransactionSource, TransactionValidityError},
+	transaction_validity::{InvalidTransaction, TransactionValidityError},
 	DispatchError,
 };
 
@@ -359,7 +359,7 @@ fn transaction_with_to_low_nonce_should_not_work() {
 }
 
 #[test]
-fn transaction_with_to_hight_nonce_should_fail_in_block() {
+fn transaction_with_too_high_nonce_should_fail_in_block() {
 	let (pairs, mut ext) = new_test_ext(1);
 	let alice = &pairs[0];
 
@@ -376,7 +376,6 @@ fn transaction_with_to_hight_nonce_should_fail_in_block() {
 			signed: fp_self_contained::CheckedSignature::SelfContained(source),
 			function: Call::Ethereum(call),
 		};
-		use frame_support::weights::GetDispatchInfo as _;
 		let dispatch_info = extrinsic.get_dispatch_info();
 		assert_err!(
 			extrinsic.apply::<Test>(&dispatch_info, 0),
@@ -404,7 +403,6 @@ fn transaction_with_invalid_chain_id_should_fail_in_block() {
 			signed: fp_self_contained::CheckedSignature::SelfContained(source),
 			function: Call::Ethereum(call),
 		};
-		use frame_support::weights::GetDispatchInfo as _;
 		let dispatch_info = extrinsic.get_dispatch_info();
 		assert_err!(
 			extrinsic.apply::<Test>(&dispatch_info, 0),
@@ -451,8 +449,6 @@ fn source_should_be_derived_from_signature() {
 	let alice_storage_address = storage_address(alice.address, H256::zero());
 
 	ext.execute_with(|| {
-		let mut transaction = creation_contract(ERC20_CONTRACT_BYTECODE, 0);
-
 		Ethereum::transact(
 			RawOrigin::EthereumTransaction(alice.address).into(),
 			sign_transaction(alice, creation_contract(ERC20_CONTRACT_BYTECODE, 0)),
@@ -588,133 +584,133 @@ fn call_should_handle_errors() {
 	});
 }
 
-// #[test]
-// fn root_transact_invalid_origin_should_fail() {
-// 	let (pairs, mut ext) = new_test_ext(1);
-// 	let alice = &pairs[0];
+#[test]
+fn root_transact_invalid_origin_should_fail() {
+	let (pairs, mut ext) = new_test_ext(1);
+	let alice = &pairs[0];
 
-// 	ext.execute_with(|| {
-// 		let t = UnsignedTransaction {
-// 			nonce: U256::zero(),
-// 			gas_price: U256::from(1),
-// 			gas_limit: U256::from(0x100000),
-// 			action: ethereum::TransactionAction::Create,
-// 			value: U256::zero(),
-// 			input: hex2bytes_unchecked(TEST_CONTRACT_BYTECODE),
-// 		}
-// 		.sign(&alice.private_key);
-// 		// Deploy contract
-// 		assert_ok!(Ethereum::execute(
-// 			alice.address,
-// 			t.input,
-// 			t.value,
-// 			t.gas_limit,
-// 			Some(t.gas_price),
-// 			Some(t.nonce),
-// 			t.action,
-// 			None,
-// 		));
-// 		let contract_address: H160 =
-// 			array_bytes::hex_into_unchecked("32dcab0ef3fb2de2fce1d2e0799d36239671f04a");
-// 		let add: Vec<u8> = hex2bytes_unchecked(
-// 			"1003e2d20000000000000000000000000000000000000000000000000000000000000002",
-// 		);
+	ext.execute_with(|| {
+		let t = UnsignedTransaction {
+			nonce: U256::zero(),
+			gas_price: U256::from(1),
+			gas_limit: U256::from(0x100000),
+			action: ethereum::TransactionAction::Create,
+			value: U256::zero(),
+			input: hex2bytes_unchecked(TEST_CONTRACT_BYTECODE),
+		}
+		.sign(&alice.private_key);
+		// Deploy contract
+		assert_ok!(Ethereum::execute(
+			alice.address,
+			t.input,
+			t.value,
+			t.gas_limit,
+			Some(t.gas_price),
+			Some(t.nonce),
+			t.action,
+			None,
+		));
+		let contract_address: H160 =
+			array_bytes::hex_into_unchecked("32dcab0ef3fb2de2fce1d2e0799d36239671f04a");
+		let add: Vec<u8> = hex2bytes_unchecked(
+			"1003e2d20000000000000000000000000000000000000000000000000000000000000002",
+		);
 
-// 		assert_noop!(
-// 			Ethereum::root_transact(Origin::none(), contract_address, add.clone()),
-// 			sp_runtime::traits::BadOrigin,
-// 		);
-// 	});
-// }
+		assert_noop!(
+			Ethereum::root_transact(Origin::none(), contract_address, add.clone()),
+			sp_runtime::traits::BadOrigin,
+		);
+	});
+}
 
-// #[test]
-// fn root_transact_should_works() {
-// 	let (pairs, mut ext) = new_test_ext(1);
-// 	let alice = &pairs[0];
+#[test]
+fn root_transact_should_works() {
+	let (pairs, mut ext) = new_test_ext(1);
+	let alice = &pairs[0];
 
-// 	ext.execute_with(|| {
-// 		let t = UnsignedTransaction {
-// 			nonce: U256::zero(),
-// 			gas_price: U256::from(1),
-// 			gas_limit: U256::from(0x100000),
-// 			action: ethereum::TransactionAction::Create,
-// 			value: U256::zero(),
-// 			input: hex2bytes_unchecked(TEST_CONTRACT_BYTECODE),
-// 		}
-// 		.sign(&alice.private_key);
-// 		// Deploy contract
-// 		assert_ok!(Ethereum::execute(
-// 			alice.address,
-// 			t.input,
-// 			t.value,
-// 			t.gas_limit,
-// 			Some(t.gas_price),
-// 			Some(t.nonce),
-// 			t.action,
-// 			None,
-// 		));
-// 		let contract_address: H160 =
-// 			array_bytes::hex_into_unchecked("32dcab0ef3fb2de2fce1d2e0799d36239671f04a");
-// 		let number: Vec<u8> = hex2bytes_unchecked("0x8381f58a");
-// 		let add: Vec<u8> = hex2bytes_unchecked(
-// 			"1003e2d20000000000000000000000000000000000000000000000000000000000000002",
-// 		);
+	ext.execute_with(|| {
+		let t = UnsignedTransaction {
+			nonce: U256::zero(),
+			gas_price: U256::from(1),
+			gas_limit: U256::from(0x100000),
+			action: ethereum::TransactionAction::Create,
+			value: U256::zero(),
+			input: hex2bytes_unchecked(TEST_CONTRACT_BYTECODE),
+		}
+		.sign(&alice.private_key);
+		// Deploy contract
+		assert_ok!(Ethereum::execute(
+			alice.address,
+			t.input,
+			t.value,
+			t.gas_limit,
+			Some(t.gas_price),
+			Some(t.nonce),
+			t.action,
+			None,
+		));
+		let contract_address: H160 =
+			array_bytes::hex_into_unchecked("32dcab0ef3fb2de2fce1d2e0799d36239671f04a");
+		let number: Vec<u8> = hex2bytes_unchecked("0x8381f58a");
+		let add: Vec<u8> = hex2bytes_unchecked(
+			"1003e2d20000000000000000000000000000000000000000000000000000000000000002",
+		);
 
-// 		assert_ok!(Ethereum::root_transact(
-// 			Origin::root(),
-// 			contract_address,
-// 			add.clone()
-// 		));
+		assert_ok!(Ethereum::root_transact(
+			Origin::root(),
+			contract_address,
+			add.clone()
+		));
 
-// 		let result = Ethereum::read_only_call(contract_address, number.clone()).unwrap();
-// 		assert_eq!(
-// 			result,
-// 			vec![
-// 				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-// 				0, 0, 0, 2
-// 			]
-// 		);
-// 	});
-// }
+		let result = Ethereum::read_only_call(contract_address, number.clone()).unwrap();
+		assert_eq!(
+			result,
+			vec![
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 2
+			]
+		);
+	});
+}
 
-// #[test]
-// fn root_transact_invalid_data_should_fail() {
-// 	let (pairs, mut ext) = new_test_ext(1);
-// 	let alice = &pairs[0];
+#[test]
+fn root_transact_invalid_data_should_fail() {
+	let (pairs, mut ext) = new_test_ext(1);
+	let alice = &pairs[0];
 
-// 	ext.execute_with(|| {
-// 		let t = UnsignedTransaction {
-// 			nonce: U256::zero(),
-// 			gas_price: U256::from(1),
-// 			gas_limit: U256::from(0x100000),
-// 			action: ethereum::TransactionAction::Create,
-// 			value: U256::zero(),
-// 			input: hex2bytes_unchecked(TEST_CONTRACT_BYTECODE),
-// 		}
-// 		.sign(&alice.private_key);
-// 		// Deploy contract
-// 		assert_ok!(Ethereum::execute(
-// 			alice.address,
-// 			t.input,
-// 			t.value,
-// 			t.gas_limit,
-// 			Some(t.gas_price),
-// 			Some(t.nonce),
-// 			t.action,
-// 			None,
-// 		));
-// 		let contract_address: H160 =
-// 			array_bytes::hex_into_unchecked("32dcab0ef3fb2de2fce1d2e0799d36239671f04a");
-// 		let wrong_add: Vec<u8> = hex2bytes_unchecked(
-// 			"0003e2d20000000000000000000000000000000000000000000000000000000000000002",
-// 		);
+	ext.execute_with(|| {
+		let t = UnsignedTransaction {
+			nonce: U256::zero(),
+			gas_price: U256::from(1),
+			gas_limit: U256::from(0x100000),
+			action: ethereum::TransactionAction::Create,
+			value: U256::zero(),
+			input: hex2bytes_unchecked(TEST_CONTRACT_BYTECODE),
+		}
+		.sign(&alice.private_key);
+		// Deploy contract
+		assert_ok!(Ethereum::execute(
+			alice.address,
+			t.input,
+			t.value,
+			t.gas_limit,
+			Some(t.gas_price),
+			Some(t.nonce),
+			t.action,
+			None,
+		));
+		let contract_address: H160 =
+			array_bytes::hex_into_unchecked("32dcab0ef3fb2de2fce1d2e0799d36239671f04a");
+		let wrong_add: Vec<u8> = hex2bytes_unchecked(
+			"0003e2d20000000000000000000000000000000000000000000000000000000000000002",
+		);
 
-// 		assert_err!(
-// 			Ethereum::root_transact(Origin::root(), contract_address, wrong_add),
-// 			<Error<Test>>::InternalTransactionRevertError
-// 		);
-// 	});
-// }
+		assert_err!(
+			Ethereum::root_transact(Origin::root(), contract_address, wrong_add),
+			<Error<Test>>::InternalTransactionRevertError
+		);
+	});
+}
 
 #[test]
 fn read_only_call_should_works() {

--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -35,7 +35,7 @@ sp-io              = { default-features = false, git = "https://github.com/darwi
 sp-runtime         = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 sp-std             = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 # frontier
-fp-evm = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.0" }
+fp-evm = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
 
 [dev-dependencies]
 # darwinia-network

--- a/frame/evm/precompile/contracts/bridge/bsc/Cargo.toml
+++ b/frame/evm/precompile/contracts/bridge/bsc/Cargo.toml
@@ -20,7 +20,7 @@ darwinia-evm-precompile-utils = { default-features = false, path = "../../utils"
 dp-contract                   = { default-features = false, path = "../../../../../../primitives/contract" }
 ethereum-primitives           = { default-features = false, features = ["full-codec", "full-rlp"], path = "../../../../../../primitives/ethereum" }
 # frontier
-fp-evm = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.0" }
+fp-evm = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
 
 [features]
 default = ["std"]

--- a/frame/evm/precompile/contracts/bridge/bsc/Cargo.toml
+++ b/frame/evm/precompile/contracts/bridge/bsc/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "darwinia-evm-precompile-bridge-bsc"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common/"
-version     = "2.7.1"
+version     = "2.7.2"
 
 [dependencies]
 # crates.io

--- a/frame/evm/precompile/contracts/bridge/ethereum/Cargo.toml
+++ b/frame/evm/precompile/contracts/bridge/ethereum/Cargo.toml
@@ -23,7 +23,7 @@ sp-core = { default-features = false, git = "https://github.com/darwinia-network
 sp-io   = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 sp-std  = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 # frontier
-fp-evm  = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.0" }
+fp-evm  = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
 
 [features]
 default = ["std"]

--- a/frame/evm/precompile/contracts/bridge/s2s/Cargo.toml
+++ b/frame/evm/precompile/contracts/bridge/s2s/Cargo.toml
@@ -29,7 +29,7 @@ sp-core             = { default-features = false, git = "https://github.com/darw
 sp-io               = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 sp-std              = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 # frontier
-fp-evm = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.0" }
+fp-evm = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
 
 [features]
 default = ["std"]

--- a/frame/evm/precompile/contracts/dispatch/Cargo.toml
+++ b/frame/evm/precompile/contracts/dispatch/Cargo.toml
@@ -22,7 +22,7 @@ frame-support = { default-features = false, git = "https://github.com/darwinia-n
 sp-core       = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 sp-io         = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 # frontier
-fp-evm = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.0" }
+fp-evm = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
 
 [features]
 default = ["std"]

--- a/frame/evm/precompile/contracts/transfer/Cargo.toml
+++ b/frame/evm/precompile/contracts/transfer/Cargo.toml
@@ -27,7 +27,7 @@ frame-system     = { default-features = false, git = "https://github.com/darwini
 sp-core          = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 sp-std           = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 # frontier
-fp-evm  = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.0" }
+fp-evm  = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
 
 [features]
 default = ["std"]

--- a/frame/support/src/evm.rs
+++ b/frame/support/src/evm.rs
@@ -105,49 +105,45 @@ pub fn recover_signer(transaction: &ethereum::TransactionV0) -> Option<H160> {
 
 /// The dvm transaction used by inner pallets, such as ethereum-issuing.
 pub struct DVMTransaction {
-	/// source of the transaction
-	pub source: H160,
 	/// gas price wrapped by Option
 	pub gas_price: Option<U256>,
 	/// the transaction defined in ethereum lib
 	pub tx: ethereum::TransactionV0,
 }
 
-impl DVMTransaction {
-	/// the internal transaction usually used by pallets
-	/// the source account is specified by pallet dvm account
-	/// gas_price is None means no need for gas fee
-	/// a default signature which will not be verified
-	pub fn new_internal_transaction(
-		source: H160,
-		nonce: U256,
-		target: H160,
-		input: Vec<u8>,
-	) -> Self {
-		let transaction = ethereum::TransactionV0 {
-			nonce,
-			// Not used, and will be overwritten by None later.
-			gas_price: U256::zero(),
-			gas_limit: U256::from(INTERNAL_TX_GAS_LIMIT),
-			action: ethereum::TransactionAction::Call(target),
-			value: U256::zero(),
-			input,
-			signature: ethereum::TransactionSignature::new(
-				// Reference https://github.com/ethereum/EIPs/issues/155
-				//
-				// But this transaction is sent by darwinia-issuing system from `0x0`
-				// So ignore signature checking, simply set `chain_id` to `1`
-				1 * 2 + 36,
-				H256::from_slice(&[55u8; 32]),
-				H256::from_slice(&[55u8; 32]),
-			)
-			.unwrap(),
-		};
+impl From<ethereum::TransactionV0> for DVMTransaction {
+	fn from(transaction: ethereum::TransactionV0) -> Self {
 		Self {
-			source,
-			gas_price: None,
+			gas_price: Some(transaction.gas_price),
 			tx: transaction,
 		}
+	}
+}
+
+pub fn new_internal_transaction(nonce: U256, target: H160, input: Vec<u8>) -> DVMTransaction {
+	let transaction = ethereum::TransactionV0 {
+		nonce,
+		// Not used, and will be overwritten by None later.
+		gas_price: U256::zero(),
+		gas_limit: U256::from(INTERNAL_TX_GAS_LIMIT),
+		action: ethereum::TransactionAction::Call(target),
+		value: U256::zero(),
+		input,
+		signature: ethereum::TransactionSignature::new(
+			// Reference https://github.com/ethereum/EIPs/issues/155
+			//
+			// But this transaction is sent by darwinia-issuing system from `0x0`
+			// So ignore signature checking, simply set `chain_id` to `1`
+			1 * 2 + 36,
+			H256::from_slice(&[55u8; 32]),
+			H256::from_slice(&[55u8; 32]),
+		)
+		.unwrap(),
+	};
+
+	DVMTransaction {
+		gas_price: None,
+		tx: transaction,
 	}
 }
 

--- a/frame/wormhole/issuing/ethereum/Cargo.toml
+++ b/frame/wormhole/issuing/ethereum/Cargo.toml
@@ -30,7 +30,7 @@ frame-system       = { default-features = false, git = "https://github.com/darwi
 sp-runtime         = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 sp-std             = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 # frontier
-fp-evm            = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.0" }
+fp-evm            = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
 
 [features]
 default = ["std"]

--- a/frame/wormhole/issuing/s2s/Cargo.toml
+++ b/frame/wormhole/issuing/s2s/Cargo.toml
@@ -37,7 +37,7 @@ sp-io               = { default-features = false, git = "https://github.com/darw
 sp-runtime          = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 sp-std              = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 # frontier
-fp-evm            = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.0" }
+fp-evm            = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
 
 [dev-dependencies]
 # crates.io

--- a/frame/wormhole/issuing/s2s/Cargo.toml
+++ b/frame/wormhole/issuing/s2s/Cargo.toml
@@ -48,6 +48,8 @@ rlp          = { version = "0.5" }
 # darwinia-network
 darwinia-balances = { path = "../../../balances" }
 pallet-timestamp  = { git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
+# frontier
+fp-self-contained = { git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
 
 [features]
 default = ["std"]

--- a/node/rpc/Cargo.toml
+++ b/node/rpc/Cargo.toml
@@ -47,7 +47,7 @@ sp-keystore                    = { git = "https://github.com/darwinia-network/su
 sp-runtime                     = { git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 substrate-frame-rpc-system     = { git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 # frontier
-fc-rpc-core = { git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.0" }
+fc-rpc-core = { git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
 # template
 futures                  = { version = "0.3", optional = true }
 sc-consensus-manual-seal = { optional = true, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }

--- a/node/runtime/pangolin/Cargo.toml
+++ b/node/runtime/pangolin/Cargo.toml
@@ -123,8 +123,8 @@ sp-std                                     = { default-features = false, git = "
 sp-transaction-pool                        = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 sp-version                                 = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 # frontier
-fp-evm                       = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.0" }
-pallet-evm-precompile-simple = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.0" }
+fp-evm                       = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
+pallet-evm-precompile-simple = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
 
 [build-dependencies]
 # paritytech

--- a/node/runtime/pangolin/Cargo.toml
+++ b/node/runtime/pangolin/Cargo.toml
@@ -124,6 +124,7 @@ sp-transaction-pool                        = { default-features = false, git = "
 sp-version                                 = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 # frontier
 fp-evm                       = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
+fp-self-contained            = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
 pallet-evm-precompile-simple = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
 
 [build-dependencies]
@@ -245,6 +246,7 @@ std = [
 	"sha3/std",
 	# frontier
 	"fp-evm/std",
+	"fp-self-contained/std",
 	"pallet-evm-precompile-simple/std",
 ]
 

--- a/node/runtime/pangolin/src/lib.rs
+++ b/node/runtime/pangolin/src/lib.rs
@@ -753,7 +753,7 @@ sp_api::impl_runtime_apis! {
 				// Apply the a subset of extrinsics: all the substrate-specific or ethereum
 				// transactions that preceded the requested transaction.
 				for ext in _extrinsics.into_iter() {
-					let _ = match &ext.function {
+					let _ = match &ext.0.function {
 						Call::Ethereum(transact { transaction }) => {
 							if transaction == _traced_transaction {
 								EvmTracer::new().trace(|| Executive::apply_extrinsic(ext));
@@ -793,7 +793,7 @@ sp_api::impl_runtime_apis! {
 
 				// Apply all extrinsics. Ethereum extrinsics are traced.
 				for ext in _extrinsics.into_iter() {
-					match &ext.function {
+					match &ext.0.function {
 						Call::Ethereum(transact { transaction }) => {
 							let eth_extrinsic_hash =
 								H256::from_slice(Keccak256::digest(&rlp::encode(transaction)).as_slice());

--- a/node/runtime/pangolin/src/lib.rs
+++ b/node/runtime/pangolin/src/lib.rs
@@ -148,11 +148,8 @@ pub type SignedExtra = (
 	CheckEthereumRelayHeaderParcel<Runtime>,
 );
 /// Unchecked extrinsic type as expected by this runtime.
-// pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, Call, Signature, SignedExtra>;
 pub type UncheckedExtrinsic =
 	fp_self_contained::UncheckedExtrinsic<Address, Call, Signature, SignedExtra>;
-// TODO:
-// pub type CheckedExtrinsic = fp_self_contained::CheckedExtrinsic<AccountId, Call, SignedExtra, H160>;
 /// Executive: handles dispatch to the various modules.
 pub type Executive = frame_executive::Executive<
 	Runtime,

--- a/node/runtime/pangolin/src/lib.rs
+++ b/node/runtime/pangolin/src/lib.rs
@@ -107,8 +107,11 @@ use sp_consensus_babe::{AllowedSlots, BabeEpochConfiguration};
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata, H160, H256, U256};
 use sp_runtime::{
 	generic,
-	traits::{Block as BlockT, Extrinsic, NumberFor, SaturatedConversion, StaticLookup, Verify},
-	transaction_validity::{TransactionSource, TransactionValidity},
+	traits::{
+		Block as BlockT, Dispatchable, Extrinsic, NumberFor, PostDispatchInfoOf,
+		SaturatedConversion, StaticLookup, Verify,
+	},
+	transaction_validity::{TransactionSource, TransactionValidity, TransactionValidityError},
 	ApplyExtrinsicResult, MultiAddress, OpaqueExtrinsic,
 };
 use sp_std::prelude::*;
@@ -145,7 +148,11 @@ pub type SignedExtra = (
 	CheckEthereumRelayHeaderParcel<Runtime>,
 );
 /// Unchecked extrinsic type as expected by this runtime.
-pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, Call, Signature, SignedExtra>;
+// pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, Call, Signature, SignedExtra>;
+pub type UncheckedExtrinsic =
+	fp_self_contained::UncheckedExtrinsic<Address, Call, Signature, SignedExtra>;
+// TODO:
+// pub type CheckedExtrinsic = fp_self_contained::CheckedExtrinsic<AccountId, Call, SignedExtra, H160>;
 /// Executive: handles dispatch to the various modules.
 pub type Executive = frame_executive::Executive<
 	Runtime,
@@ -272,7 +279,7 @@ frame_support::construct_runtime! {
 		TronBacking: to_tron_backing::{Pallet, Config<T>} = 39,
 
 		EVM: darwinia_evm::{Pallet, Call, Storage, Config, Event<T>} = 40,
-		Ethereum: dvm_ethereum::{Pallet, Call, Storage, Config, Event, ValidateUnsigned} = 41,
+		Ethereum: dvm_ethereum::{Pallet, Call, Storage, Config, Event, Origin} = 41,
 		// DynamicFee: dvm_dynamic_fee::{Pallet, Call, Storage, Inherent} = 47,
 
 		BridgePangoroDispatch: pallet_bridge_dispatch::<Instance1>::{Pallet, Event<T>} = 44,
@@ -340,6 +347,43 @@ where
 {
 	type Extrinsic = UncheckedExtrinsic;
 	type OverarchingCall = Call;
+}
+
+impl fp_self_contained::SelfContainedCall for Call {
+	type SignedInfo = H160;
+
+	fn is_self_contained(&self) -> bool {
+		match self {
+			Call::Ethereum(call) => call.is_self_contained(),
+			_ => false,
+		}
+	}
+
+	fn check_self_contained(&self) -> Option<Result<Self::SignedInfo, TransactionValidityError>> {
+		match self {
+			Call::Ethereum(call) => call.check_self_contained(),
+			_ => None,
+		}
+	}
+
+	fn validate_self_contained(&self, info: &Self::SignedInfo) -> Option<TransactionValidity> {
+		match self {
+			Call::Ethereum(call) => call.validate_self_contained(info),
+			_ => None,
+		}
+	}
+
+	fn apply_self_contained(
+		self,
+		info: Self::SignedInfo,
+	) -> Option<sp_runtime::DispatchResultWithInfo<PostDispatchInfoOf<Self>>> {
+		match self {
+			call @ Call::Ethereum(pallet_ethereum::Call::transact(_)) => Some(call.dispatch(
+				Origin::from(dvm_ethereum::RawOrigin::EthereumTransaction(info)),
+			)),
+			_ => None,
+		}
+	}
 }
 
 sp_api::impl_runtime_apis! {
@@ -677,7 +721,7 @@ sp_api::impl_runtime_apis! {
 		fn extrinsic_filter(
 			xts: Vec<<Block as BlockT>::Extrinsic>,
 		) -> Vec<dvm_ethereum::TransactionV0> {
-			xts.into_iter().filter_map(|xt| match xt.function {
+			xts.into_iter().filter_map(|xt| match xt.0.function {
 				Call::Ethereum(dvm_ethereum::Call::transact { transaction }) => Some(transaction),
 				_ => None
 			}).collect()

--- a/node/runtime/pangolin/src/lib.rs
+++ b/node/runtime/pangolin/src/lib.rs
@@ -373,12 +373,22 @@ impl fp_self_contained::SelfContainedCall for Call {
 		}
 	}
 
+	fn pre_dispatch_self_contained(
+		&self,
+		info: &Self::SignedInfo,
+	) -> Option<Result<(), TransactionValidityError>> {
+		match self {
+			Call::Ethereum(call) => call.pre_dispatch_self_contained(info),
+			_ => None,
+		}
+	}
+
 	fn apply_self_contained(
 		self,
 		info: Self::SignedInfo,
 	) -> Option<sp_runtime::DispatchResultWithInfo<PostDispatchInfoOf<Self>>> {
 		match self {
-			call @ Call::Ethereum(pallet_ethereum::Call::transact(_)) => Some(call.dispatch(
+			call @ Call::Ethereum(dvm_ethereum::Call::transact { .. }) => Some(call.dispatch(
 				Origin::from(dvm_ethereum::RawOrigin::EthereumTransaction(info)),
 			)),
 			_ => None,

--- a/node/runtime/template/Cargo.toml
+++ b/node/runtime/template/Cargo.toml
@@ -54,6 +54,7 @@ sp-std                                     = { default-features = false, git = "
 sp-transaction-pool                        = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 sp-version                                 = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 # frontier
+fp-self-contained              = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
 pallet-evm-precompile-simple   = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
 pallet-evm-precompile-sha3fips = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
 pallet-evm-precompile-modexp   = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
@@ -109,6 +110,7 @@ std = [
 	"sp-transaction-pool/std",
 	"sp-version/std",
 	# frontier
+	"fp-self-contained/std",
 	"pallet-evm-precompile-modexp/std",
 	"pallet-evm-precompile-sha3fips/std",
 	"pallet-evm-precompile-simple/std",

--- a/node/runtime/template/Cargo.toml
+++ b/node/runtime/template/Cargo.toml
@@ -54,9 +54,9 @@ sp-std                                     = { default-features = false, git = "
 sp-transaction-pool                        = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 sp-version                                 = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 # frontier
-pallet-evm-precompile-modexp   = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.0" }
-pallet-evm-precompile-sha3fips = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.0" }
-pallet-evm-precompile-simple   = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.0" }
+pallet-evm-precompile-simple   = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
+pallet-evm-precompile-sha3fips = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
+pallet-evm-precompile-modexp   = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
 
 [build-dependencies]
 substrate-wasm-builder = { git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }

--- a/node/runtime/template/src/lib.rs
+++ b/node/runtime/template/src/lib.rs
@@ -88,11 +88,8 @@ pub type SignedExtra = (
 	CheckWeight<Runtime>,
 	ChargeTransactionPayment<Runtime>,
 );
-// pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, Call, Signature, SignedExtra>;
 pub type UncheckedExtrinsic =
 	fp_self_contained::UncheckedExtrinsic<Address, Call, Signature, SignedExtra>;
-// TODO:
-// pub type CheckedExtrinsic = fp_self_contained::CheckedExtrinsic<AccountId, Call, SignedExtra, H160>;
 pub type Executive =
 	frame_executive::Executive<Runtime, Block, ChainContext<Runtime>, Runtime, AllPallets>;
 pub type SignedPayload = generic::SignedPayload<Call, SignedExtra>;

--- a/node/runtime/template/src/lib.rs
+++ b/node/runtime/template/src/lib.rs
@@ -167,6 +167,16 @@ impl fp_self_contained::SelfContainedCall for Call {
 		}
 	}
 
+	fn pre_dispatch_self_contained(
+		&self,
+		info: &Self::SignedInfo,
+	) -> Option<Result<(), TransactionValidityError>> {
+		match self {
+			Call::Ethereum(call) => call.pre_dispatch_self_contained(info),
+			_ => None,
+		}
+	}
+
 	fn apply_self_contained(
 		self,
 		info: Self::SignedInfo,

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -76,7 +76,7 @@ sp-transaction-pool                        = { git = "https://github.com/darwini
 sp-trie                                    = { git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 substrate-prometheus-endpoint              = { git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }
 # frontier
-fc-rpc-core = { git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.0" }
+fc-rpc-core = { git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.1" }
 # template
 async-trait              = { version = "0.1", optional = true }
 sc-consensus-aura        = { optional = true, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.0" }


### PR DESCRIPTION
Companion for https://github.com/paritytech/frontier/pull/482 and https://github.com/paritytech/frontier/pull/495.

## Upgrade notice
> To use the new code, you need to change in your runtime checked and unchecked extrinsics to point to fp_self_contained::CheckedExtrinsic and fp_self_contained::UncheckedExtrinsic. This will also require you to implement SelfContainedCall trait for runtime Call, which the node template contains sample code.

We rely on the darwinia-frontier branch 0.12.1(The main branch is darwinia-frontier 0.12.0). Might merge these changes to 0.12.0 and upgrade to pangolin directly.