### PR TITLE
Improve `PrecompileOutput`'s `exit_status`

### DIFF
--- a/frame/dvm/evm/precompiles/bridge/bsc/src/lib.rs
+++ b/frame/dvm/evm/precompiles/bridge/bsc/src/lib.rs
@@ -154,7 +154,7 @@ where
 		};
 
 		Ok(PrecompileOutput {
-			exit_status: ExitSucceed::Stopped,
+			exit_status: ExitSucceed::Returned,
 			cost,
 			output,
 			logs: Default::default(),

--- a/frame/dvm/evm/precompiles/bridge/ethereum/src/lib.rs
+++ b/frame/dvm/evm/precompiles/bridge/ethereum/src/lib.rs
@@ -74,7 +74,7 @@ where
 		};
 
 		Ok(PrecompileOutput {
-			exit_status: ExitSucceed::Stopped,
+			exit_status: ExitSucceed::Returned,
 			cost: 20000,
 			output,
 			logs: Default::default(),

--- a/frame/dvm/evm/precompiles/dispatch/src/lib.rs
+++ b/frame/dvm/evm/precompiles/dispatch/src/lib.rs
@@ -78,7 +78,7 @@ where
 					post_info.actual_weight.unwrap_or(info.weight),
 				);
 				Ok(PrecompileOutput {
-					exit_status: ExitSucceed::Stopped,
+					exit_status: ExitSucceed::Returned,
 					cost,
 					output: Default::default(),
 					logs: Default::default(),

--- a/node/service/src/service/mod.rs
+++ b/node/service/src/service/mod.rs
@@ -329,7 +329,6 @@ where
 			justification_sync_link: network.clone(),
 			create_inherent_data_providers: move |parent, ()| {
 				let client_clone = client_clone.clone();
-
 				async move {
 					let uncles = sc_consensus_uncles::create_uncles_inherent_data_provider(
 						&*client_clone,

--- a/node/service/src/service/mod.rs
+++ b/node/service/src/service/mod.rs
@@ -329,7 +329,7 @@ where
 			justification_sync_link: network.clone(),
 			create_inherent_data_providers: move |parent, ()| {
 				let client_clone = client_clone.clone();
-				
+
 				async move {
 					let uncles = sc_consensus_uncles::create_uncles_inherent_data_provider(
 						&*client_clone,


### PR DESCRIPTION
`Stopped` and `Returned` both work, but, literally, `Returned` is better.