### PR TITLE
Make fee market instantiable

### DIFF
--- a/frame/fee-market/rpc/runtime-api/src/lib.rs
+++ b/frame/fee-market/rpc/runtime-api/src/lib.rs
@@ -80,9 +80,8 @@ decl_runtime_apis! {
 	where
 		Balance: Codec + MaybeDisplay + MaybeFromStr,
 	 {
-		fn market_fee(
-		) -> Option<Fee<Balance>>;
+		fn market_fee(instance: u8) -> Option<Fee<Balance>>;
 
-		fn in_process_orders() -> InProcessOrders;
+		fn in_process_orders(instance: u8) -> InProcessOrders;
 	}
 }

--- a/frame/fee-market/rpc/src/lib.rs
+++ b/frame/fee-market/rpc/src/lib.rs
@@ -42,9 +42,9 @@ const RUNTIME_ERROR: i64 = -1;
 #[rpc]
 pub trait FeeMarketApi<Fee> {
 	#[rpc(name = "fee_marketFee")]
-	fn market_fee(&self) -> Result<Option<Fee>>;
+	fn market_fee(&self, instance: u8) -> Result<Option<Fee>>;
 	#[rpc(name = "fee_inProcessOrders")]
-	fn in_process_orders(&self) -> Result<InProcessOrders>;
+	fn in_process_orders(&self, instance: u8) -> Result<InProcessOrders>;
 }
 
 pub struct FeeMarket<Client, Block, Balance> {
@@ -68,24 +68,24 @@ where
 	Block: BlockT,
 	Balance: 'static + Sync + Send + Codec + MaybeDisplay + MaybeFromStr,
 {
-	fn market_fee(&self) -> Result<Option<Fee<Balance>>> {
+	fn market_fee(&self, instance: u8) -> Result<Option<Fee<Balance>>> {
 		let api = self.client.runtime_api();
 		let best = self.client.info().best_hash;
 		let at = BlockId::hash(best);
 
-		api.market_fee(&at).map_err(|e| Error {
+		api.market_fee(&at, instance).map_err(|e| Error {
 			code: ErrorCode::ServerError(RUNTIME_ERROR),
 			message: "Unable to query market fee.".into(),
 			data: Some(format!("{:?}", e).into()),
 		})
 	}
 
-	fn in_process_orders(&self) -> Result<InProcessOrders> {
+	fn in_process_orders(&self, instance: u8) -> Result<InProcessOrders> {
 		let api = self.client.runtime_api();
 		let best = self.client.info().best_hash;
 		let at = BlockId::hash(best);
 
-		api.in_process_orders(&at).map_err(|e| Error {
+		api.in_process_orders(&at, instance).map_err(|e| Error {
 			code: ErrorCode::ServerError(RUNTIME_ERROR),
 			message: "Unable to query in process orders.".into(),
 			data: Some(format!("{:?}", e).into()),

--- a/frame/fee-market/src/lib.rs
+++ b/frame/fee-market/src/lib.rs
@@ -51,8 +51,7 @@ use darwinia_support::balance::{LockFor, LockableCurrency};
 use types::{Order, Relayer, SlashReport};
 
 pub type AccountId<T> = <T as frame_system::Config>::AccountId;
-pub type RingBalance<T, I = ()> =
-	<<T as Config<I>>::RingCurrency as Currency<AccountId<T>>>::Balance;
+pub type RingBalance<T, I> = <<T as Config<I>>::RingCurrency as Currency<AccountId<T>>>::Balance;
 
 #[frame_support::pallet]
 pub mod pallet {

--- a/frame/fee-market/src/lib.rs
+++ b/frame/fee-market/src/lib.rs
@@ -29,7 +29,7 @@ mod tests;
 pub mod weight;
 pub use weight::WeightInfo;
 
-// pub mod s2s;
+pub mod s2s;
 pub mod types;
 
 // --- paritytech ---

--- a/frame/fee-market/src/lib.rs
+++ b/frame/fee-market/src/lib.rs
@@ -51,7 +51,8 @@ use darwinia_support::balance::{LockFor, LockableCurrency};
 use types::{Order, Relayer, SlashReport};
 
 pub type AccountId<T> = <T as frame_system::Config>::AccountId;
-pub type RingBalance<T> = <<T as Config>::RingCurrency as Currency<AccountId<T>>>::Balance;
+pub type RingBalance<T, I = ()> =
+	<<T as Config<I>>::RingCurrency as Currency<AccountId<T>>>::Balance;
 
 #[frame_support::pallet]
 pub mod pallet {
@@ -69,10 +70,10 @@ pub mod pallet {
 
 		/// The minimum fee for relaying.
 		#[pallet::constant]
-		type MinimumRelayFee: Get<RingBalance<Self>>;
+		type MinimumRelayFee: Get<RingBalance<Self, I>>;
 		/// The collateral relayer need to lock for each order.
 		#[pallet::constant]
-		type CollateralPerOrder: Get<RingBalance<Self>>;
+		type CollateralPerOrder: Get<RingBalance<Self, I>>;
 		/// The slot times set
 		#[pallet::constant]
 		type Slot: Get<Self::BlockNumber>;
@@ -86,7 +87,7 @@ pub mod pallet {
 		type ConfirmRelayersRewardRatio: Get<Permill>;
 
 		/// The slash rule
-		type Slasher: Slasher<Self>;
+		type Slasher: Slasher<Self, I>;
 		type RingCurrency: LockableCurrency<Self::AccountId, Moment = Self::BlockNumber>;
 
 		type Event: From<Event<Self, I>> + IsType<<Self as frame_system::Config>::Event>;
@@ -97,19 +98,19 @@ pub mod pallet {
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config<I>, I: 'static = ()> {
 		/// Relayer enrollment. \[account_id, locked_collateral, relay_fee\]
-		Enroll(T::AccountId, RingBalance<T>, RingBalance<T>),
+		Enroll(T::AccountId, RingBalance<T, I>, RingBalance<T, I>),
 		/// Update relayer locked collateral. \[account_id, new_collateral\]
-		UpdateLockedCollateral(T::AccountId, RingBalance<T>),
+		UpdateLockedCollateral(T::AccountId, RingBalance<T, I>),
 		/// Update relayer fee. \[account_id, new_fee\]
-		UpdateRelayFee(T::AccountId, RingBalance<T>),
+		UpdateRelayFee(T::AccountId, RingBalance<T, I>),
 		/// Relayer cancel enrollment. \[account_id\]
 		CancelEnrollment(T::AccountId),
 		/// Update collateral slash protect value. \[slash_protect_value\]
-		UpdateCollateralSlashProtect(RingBalance<T>),
+		UpdateCollateralSlashProtect(RingBalance<T, I>),
 		/// Update market assigned relayers numbers. \[new_assigned_relayers_number\]
 		UpdateAssignedRelayersNumber(u32),
 		/// Slash report
-		FeeMarketSlash(SlashReport<T::AccountId, T::BlockNumber, RingBalance<T>>),
+		FeeMarketSlash(SlashReport<T::AccountId, T::BlockNumber, RingBalance<T, I>>),
 	}
 
 	#[pallet::error]
@@ -135,7 +136,7 @@ pub mod pallet {
 		_,
 		Blake2_128Concat,
 		T::AccountId,
-		Relayer<T::AccountId, RingBalance<T>>,
+		Relayer<T::AccountId, RingBalance<T, I>>,
 		ValueQuery,
 	>;
 	#[pallet::storage]
@@ -147,7 +148,7 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn assigned_relayers)]
 	pub type AssignedRelayers<T: Config<I>, I: 'static = ()> =
-		StorageValue<_, Vec<Relayer<T::AccountId, RingBalance<T>>>, OptionQuery>;
+		StorageValue<_, Vec<Relayer<T::AccountId, RingBalance<T, I>>>, OptionQuery>;
 
 	// Order storage
 	#[pallet::storage]
@@ -156,14 +157,14 @@ pub mod pallet {
 		_,
 		Blake2_128Concat,
 		(LaneId, MessageNonce),
-		Order<T::AccountId, T::BlockNumber, RingBalance<T>>,
+		Order<T::AccountId, T::BlockNumber, RingBalance<T, I>>,
 		OptionQuery,
 	>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn collateral_slash_protect)]
 	pub type CollateralSlashProtect<T: Config<I>, I: 'static = ()> =
-		StorageValue<_, RingBalance<T>, OptionQuery>;
+		StorageValue<_, RingBalance<T, I>, OptionQuery>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn assigned_relayers_number)]
@@ -180,10 +181,10 @@ pub mod pallet {
 	#[pallet::hooks]
 	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>> for Pallet<T, I> {
 		fn on_finalize(_: BlockNumberFor<T>) {
-			for ((lane_id, message_nonce), order) in <Orders<T>>::iter() {
+			for ((lane_id, message_nonce), order) in <Orders<T, I>>::iter() {
 				// Once the order's confirm_time is not None, we consider this order has been rewarded. Hence, clean the storage.
 				if order.confirm_time.is_some() {
-					<Orders<T>>::remove((lane_id, message_nonce));
+					<Orders<T, I>>::remove((lane_id, message_nonce));
 				}
 			}
 		}
@@ -194,22 +195,25 @@ pub mod pallet {
 		/// Any accounts can enroll to be a relayer by lock collateral. The relay fee is optional,
 		/// the default value is MinimumRelayFee in runtime. (Update market needed)
 		/// Note: One account can enroll only once.
-		#[pallet::weight(<T as Config>::WeightInfo::enroll_and_lock_collateral())]
+		#[pallet::weight(<T as Config<I>>::WeightInfo::enroll_and_lock_collateral())]
 		#[transactional]
 		pub fn enroll_and_lock_collateral(
 			origin: OriginFor<T>,
-			lock_collateral: RingBalance<T>,
-			relay_fee: Option<RingBalance<T>>,
+			lock_collateral: RingBalance<T, I>,
+			relay_fee: Option<RingBalance<T, I>>,
 		) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
-			ensure!(!Self::is_enrolled(&who), <Error<T>>::AlreadyEnrolled);
+			ensure!(!Self::is_enrolled(&who), <Error<T, I>>::AlreadyEnrolled);
 
 			ensure!(
 				T::RingCurrency::free_balance(&who) >= lock_collateral,
-				<Error<T>>::InsufficientBalance
+				<Error<T, I>>::InsufficientBalance
 			);
 			if let Some(fee) = relay_fee {
-				ensure!(fee >= T::MinimumRelayFee::get(), <Error<T>>::RelayFeeTooLow);
+				ensure!(
+					fee >= T::MinimumRelayFee::get(),
+					<Error<T, I>>::RelayFeeTooLow
+				);
 			}
 			let fee = relay_fee.unwrap_or_else(T::MinimumRelayFee::get);
 
@@ -222,26 +226,26 @@ pub mod pallet {
 				WithdrawReasons::all(),
 			);
 			// Store enrollment detail information.
-			<RelayersMap<T>>::insert(&who, Relayer::new(who.clone(), lock_collateral, fee));
-			<Relayers<T>>::append(&who);
+			<RelayersMap<T, I>>::insert(&who, Relayer::new(who.clone(), lock_collateral, fee));
+			<Relayers<T, I>>::append(&who);
 
 			Self::update_market();
-			Self::deposit_event(Event::<T>::Enroll(who, lock_collateral, fee));
+			Self::deposit_event(Event::<T, I>::Enroll(who, lock_collateral, fee));
 			Ok(().into())
 		}
 
 		/// Update locked collateral for enrolled relayer, only supporting lock more. (Update market needed)
-		#[pallet::weight(<T as Config>::WeightInfo::update_locked_collateral())]
+		#[pallet::weight(<T as Config<I>>::WeightInfo::update_locked_collateral())]
 		#[transactional]
 		pub fn update_locked_collateral(
 			origin: OriginFor<T>,
-			new_collateral: RingBalance<T>,
+			new_collateral: RingBalance<T, I>,
 		) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
-			ensure!(Self::is_enrolled(&who), <Error<T>>::NotEnrolled);
+			ensure!(Self::is_enrolled(&who), <Error<T, I>>::NotEnrolled);
 			ensure!(
 				T::RingCurrency::free_balance(&who) >= new_collateral,
-				<Error<T>>::InsufficientBalance
+				<Error<T, I>>::InsufficientBalance
 			);
 
 			// Increase the locked collateral
@@ -259,7 +263,7 @@ pub mod pallet {
 				if let Some((_, orders_locked_collateral)) = Self::occupied(&who) {
 					ensure!(
 						new_collateral >= orders_locked_collateral,
-						<Error<T>>::StillHasOrdersNotConfirmed
+						<Error<T, I>>::StillHasOrdersNotConfirmed
 					);
 
 					T::RingCurrency::remove_lock(T::LockId::get(), &who);
@@ -274,73 +278,76 @@ pub mod pallet {
 				}
 			}
 
-			<RelayersMap<T>>::mutate(who.clone(), |relayer| {
+			<RelayersMap<T, I>>::mutate(who.clone(), |relayer| {
 				relayer.collateral = new_collateral;
 			});
 			Self::update_market();
-			Self::deposit_event(Event::<T>::UpdateLockedCollateral(who, new_collateral));
+			Self::deposit_event(Event::<T, I>::UpdateLockedCollateral(who, new_collateral));
 			Ok(().into())
 		}
 
 		/// Update relay fee for enrolled relayer. (Update market needed)
-		#[pallet::weight(<T as Config>::WeightInfo::update_relay_fee())]
+		#[pallet::weight(<T as Config<I>>::WeightInfo::update_relay_fee())]
 		#[transactional]
 		pub fn update_relay_fee(
 			origin: OriginFor<T>,
-			new_fee: RingBalance<T>,
+			new_fee: RingBalance<T, I>,
 		) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
-			ensure!(Self::is_enrolled(&who), <Error<T>>::NotEnrolled);
+			ensure!(Self::is_enrolled(&who), <Error<T, I>>::NotEnrolled);
 			ensure!(
 				new_fee >= T::MinimumRelayFee::get(),
-				<Error<T>>::RelayFeeTooLow
+				<Error<T, I>>::RelayFeeTooLow
 			);
 
-			<RelayersMap<T>>::mutate(who.clone(), |relayer| {
+			<RelayersMap<T, I>>::mutate(who.clone(), |relayer| {
 				relayer.fee = new_fee;
 			});
 
 			Self::update_market();
-			Self::deposit_event(Event::<T>::UpdateRelayFee(who, new_fee));
+			Self::deposit_event(Event::<T, I>::UpdateRelayFee(who, new_fee));
 			Ok(().into())
 		}
 
 		/// Cancel enrolled relayer(Update market needed)
-		#[pallet::weight(<T as Config>::WeightInfo::cancel_enrollment())]
+		#[pallet::weight(<T as Config<I>>::WeightInfo::cancel_enrollment())]
 		#[transactional]
 		pub fn cancel_enrollment(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
-			ensure!(Self::is_enrolled(&who), <Error<T>>::NotEnrolled);
-			ensure!(Self::occupied(&who).is_none(), <Error<T>>::OccupiedRelayer);
+			ensure!(Self::is_enrolled(&who), <Error<T, I>>::NotEnrolled);
+			ensure!(
+				Self::occupied(&who).is_none(),
+				<Error<T, I>>::OccupiedRelayer
+			);
 
 			Self::remove_enrolled_relayer(&who);
-			Self::deposit_event(Event::<T>::CancelEnrollment(who));
+			Self::deposit_event(Event::<T, I>::CancelEnrollment(who));
 			Ok(().into())
 		}
 
-		#[pallet::weight(<T as Config>::WeightInfo::set_slash_protect())]
+		#[pallet::weight(<T as Config<I>>::WeightInfo::set_slash_protect())]
 		#[transactional]
 		pub fn set_slash_protect(
 			origin: OriginFor<T>,
-			slash_protect: RingBalance<T>,
+			slash_protect: RingBalance<T, I>,
 		) -> DispatchResultWithPostInfo {
 			ensure_root(origin)?;
-			CollateralSlashProtect::<T>::put(slash_protect);
-			Self::deposit_event(Event::<T>::UpdateCollateralSlashProtect(slash_protect));
+			CollateralSlashProtect::<T, I>::put(slash_protect);
+			Self::deposit_event(Event::<T, I>::UpdateCollateralSlashProtect(slash_protect));
 			Ok(().into())
 		}
 
-		#[pallet::weight(<T as Config>::WeightInfo::set_assigned_relayers_number())]
+		#[pallet::weight(<T as Config<I>>::WeightInfo::set_assigned_relayers_number())]
 		#[transactional]
 		pub fn set_assigned_relayers_number(
 			origin: OriginFor<T>,
 			number: u32,
 		) -> DispatchResultWithPostInfo {
 			ensure_root(origin)?;
-			AssignedRelayersNumber::<T>::put(number);
+			AssignedRelayersNumber::<T, I>::put(number);
 
 			Self::update_market();
-			Self::deposit_event(Event::<T>::UpdateAssignedRelayersNumber(number));
+			Self::deposit_event(Event::<T, I>::UpdateAssignedRelayersNumber(number));
 			Ok(().into())
 		}
 	}
@@ -356,31 +363,31 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// - The order didn't confirm in-time, slash occurred.
 	pub(crate) fn update_market() {
 		// Sort all enrolled relayers who are able to accept orders.
-		let mut relayers: Vec<Relayer<T::AccountId, RingBalance<T>>> = <Relayers<T>>::get()
+		let mut relayers: Vec<Relayer<T::AccountId, RingBalance<T, I>>> = <Relayers<T, I>>::get()
 			.iter()
-			.map(RelayersMap::<T>::get)
+			.map(RelayersMap::<T, I>::get)
 			.filter(|r| Self::usable_order_capacity(&r.id) >= 1)
 			.collect();
 
 		// Select the first `AssignedRelayersNumber` relayers as AssignedRelayer.
-		let assigned_relayers_len = <AssignedRelayersNumber<T>>::get() as usize;
+		let assigned_relayers_len = <AssignedRelayersNumber<T, I>>::get() as usize;
 		if relayers.len() >= assigned_relayers_len {
 			relayers.sort();
 
 			let assigned_relayers: Vec<_> = relayers.iter().take(assigned_relayers_len).collect();
-			<AssignedRelayers<T>>::put(assigned_relayers);
+			<AssignedRelayers<T, I>>::put(assigned_relayers);
 		} else {
 			// The market fee comes from the last item in AssignedRelayers,
 			// It's would be essential to wipe this storage if relayers not enough.
-			<AssignedRelayers<T>>::kill();
+			<AssignedRelayers<T, I>>::kill();
 		}
 	}
 
 	/// Update relayer after slash occurred, this will changes RelayersMap storage. (Update market needed)
 	pub(crate) fn update_relayer_after_slash(
 		who: &T::AccountId,
-		new_collateral: RingBalance<T>,
-		report: SlashReport<T::AccountId, T::BlockNumber, RingBalance<T>>,
+		new_collateral: RingBalance<T, I>,
+		report: SlashReport<T::AccountId, T::BlockNumber, RingBalance<T, I>>,
 	) {
 		T::RingCurrency::set_lock(
 			T::LockId::get(),
@@ -390,21 +397,21 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			},
 			WithdrawReasons::all(),
 		);
-		<RelayersMap<T>>::mutate(who.clone(), |relayer| {
+		<RelayersMap<T, I>>::mutate(who.clone(), |relayer| {
 			relayer.collateral = new_collateral;
 		});
 
 		Self::update_market();
-		Self::deposit_event(<Event<T>>::FeeMarketSlash(report));
+		Self::deposit_event(<Event<T, I>>::FeeMarketSlash(report));
 	}
 
 	/// Remove enrolled relayer, then update market fee. (Update market needed)
 	pub(crate) fn remove_enrolled_relayer(who: &T::AccountId) {
 		T::RingCurrency::remove_lock(T::LockId::get(), who);
 
-		<RelayersMap<T>>::remove(who.clone());
-		<Relayers<T>>::mutate(|relayers| relayers.retain(|x| x != who));
-		<AssignedRelayers<T>>::mutate(|assigned_relayers| {
+		<RelayersMap<T, I>>::remove(who.clone());
+		<Relayers<T, I>>::mutate(|relayers| relayers.retain(|x| x != who));
+		<AssignedRelayers<T, I>>::mutate(|assigned_relayers| {
 			if let Some(relayers) = assigned_relayers {
 				relayers.retain(|x| x.id != *who);
 			}
@@ -414,25 +421,25 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 	/// Whether the relayer has enrolled
 	pub(crate) fn is_enrolled(who: &T::AccountId) -> bool {
-		<Relayers<T>>::get().iter().any(|r| *r == *who)
+		<Relayers<T, I>>::get().iter().any(|r| *r == *who)
 	}
 
 	/// Get market fee, If there is not enough relayers have order capacity to accept new order, return None.
-	pub fn market_fee() -> Option<RingBalance<T>> {
+	pub fn market_fee() -> Option<RingBalance<T, I>> {
 		Self::assigned_relayers().and_then(|relayers| relayers.last().map(|r| r.fee))
 	}
 
 	/// Get order indexes in the storage
 	pub fn in_process_orders() -> Vec<(LaneId, MessageNonce)> {
-		Orders::<T>::iter().map(|(k, _v)| k).collect()
+		Orders::<T, I>::iter().map(|(k, _v)| k).collect()
 	}
 
 	/// Whether the enrolled relayer is occupied(Responsible for order relaying)
 	/// Whether the enrolled relayer is occupied, If occupied, return the number of orders and orders locked collateral, otherwise, return None.
-	pub(crate) fn occupied(who: &T::AccountId) -> Option<(u32, RingBalance<T>)> {
+	pub(crate) fn occupied(who: &T::AccountId) -> Option<(u32, RingBalance<T, I>)> {
 		let mut count = 0u32;
-		let mut orders_locked_collateral = RingBalance::<T>::zero();
-		for (_, order) in <Orders<T>>::iter() {
+		let mut orders_locked_collateral = RingBalance::<T, I>::zero();
+		for (_, order) in <Orders<T, I>>::iter() {
 			if order.relayers_slice().iter().any(|r| r.id == *who) && !order.is_confirmed() {
 				count += 1;
 				orders_locked_collateral =
@@ -458,11 +465,11 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		Self::collateral_to_order_capacity(Self::relayer(who).collateral)
 	}
 
-	fn collateral_to_order_capacity(collateral: RingBalance<T>) -> u32 {
+	fn collateral_to_order_capacity(collateral: RingBalance<T, I>) -> u32 {
 		(collateral / T::CollateralPerOrder::get()).saturated_into::<u32>()
 	}
 }
 
-pub trait Slasher<T: Config> {
-	fn slash(locked_collateral: RingBalance<T>, timeout: T::BlockNumber) -> RingBalance<T>;
+pub trait Slasher<T: Config<I>, I: 'static> {
+	fn slash(locked_collateral: RingBalance<T, I>, timeout: T::BlockNumber) -> RingBalance<T, I>;
 }

--- a/frame/fee-market/src/s2s/callbacks.rs
+++ b/frame/fee-market/src/s2s/callbacks.rs
@@ -24,13 +24,13 @@ use bp_messages::{
 	DeliveredMessages, LaneId, MessageNonce,
 };
 
-pub struct FeeMarketMessageAcceptedHandler<T>(PhantomData<T>);
-impl<T: Config> OnMessageAccepted for FeeMarketMessageAcceptedHandler<T> {
+pub struct FeeMarketMessageAcceptedHandler<T, I>(PhantomData<(T, I)>);
+impl<T: Config<I>, I: 'static> OnMessageAccepted for FeeMarketMessageAcceptedHandler<T, I> {
 	// Called when the message is accepted by message pallet
 	fn on_messages_accepted(lane: &LaneId, message: &MessageNonce) -> Weight {
 		// Create a new order based on the latest block, assign relayers which have priority to relaying
 		let now = frame_system::Pallet::<T>::block_number();
-		if let Some(assigned_relayers) = <Pallet<T>>::assigned_relayers() {
+		if let Some(assigned_relayers) = <Pallet<T, I>>::assigned_relayers() {
 			let order = Order::new(
 				*lane,
 				*message,
@@ -40,7 +40,7 @@ impl<T: Config> OnMessageAccepted for FeeMarketMessageAcceptedHandler<T> {
 				T::Slot::get(),
 			);
 			// Store the create order
-			<Orders<T>>::insert((order.lane, order.message), order.clone());
+			<Orders<T, I>>::insert((order.lane, order.message), order.clone());
 		}
 
 		// one read for assigned relayers
@@ -49,15 +49,15 @@ impl<T: Config> OnMessageAccepted for FeeMarketMessageAcceptedHandler<T> {
 	}
 }
 
-pub struct FeeMarketMessageConfirmedHandler<T>(PhantomData<T>);
+pub struct FeeMarketMessageConfirmedHandler<T, I>(PhantomData<(T, I)>);
 
-impl<T: Config> OnDeliveryConfirmed for FeeMarketMessageConfirmedHandler<T> {
+impl<T: Config<I>, I: 'static> OnDeliveryConfirmed for FeeMarketMessageConfirmedHandler<T, I> {
 	fn on_messages_delivered(lane: &LaneId, delivered_messages: &DeliveredMessages) -> Weight {
 		let now = frame_system::Pallet::<T>::block_number();
 		for message_nonce in delivered_messages.begin..=delivered_messages.end {
-			if let Some(order) = <Orders<T>>::get((lane, message_nonce)) {
+			if let Some(order) = <Orders<T, I>>::get((lane, message_nonce)) {
 				if !order.is_confirmed() {
-					<Orders<T>>::mutate((lane, message_nonce), |order| match order {
+					<Orders<T, I>>::mutate((lane, message_nonce), |order| match order {
 						Some(order) => order.set_confirm_time(Some(now)),
 						None => {}
 					});

--- a/frame/fee-market/src/s2s/payment.rs
+++ b/frame/fee-market/src/s2s/payment.rs
@@ -35,20 +35,19 @@ use crate::{Config, Orders, Pallet, *};
 
 // TODO: Do we need to add another generic param, I2?
 // It's because the current I refers to pallet_bridge_message's instance
-pub struct FeeMarketPayment<T, BMI, FI, Currency, GetConfirmationFee, RootAccount> {
-	_phantom: sp_std::marker::PhantomData<(T, BMI, FI, Currency, GetConfirmationFee, RootAccount)>,
+pub struct FeeMarketPayment<T, BMI, FI, Currency, RootAccount> {
+	_phantom: sp_std::marker::PhantomData<(T, BMI, FI, Currency, RootAccount)>,
 }
 
-impl<T, BMI, FI, Currency, GetConfirmationFee, RootAccount>
+impl<T, BMI, FI, Currency, RootAccount>
 	MessageDeliveryAndDispatchPayment<T::AccountId, RingBalance<T, FI>>
-	for FeeMarketPayment<T, BMI, FI, Currency, GetConfirmationFee, RootAccount>
+	for FeeMarketPayment<T, BMI, FI, Currency, RootAccount>
 where
 	T: frame_system::Config + pallet_bridge_messages::Config<BMI> + Config<FI>,
 	BMI: 'static,
 	FI: 'static,
 	Currency: CurrencyT<T::AccountId, Balance = T::OutboundMessageFee>,
 	Currency::Balance: From<MessageNonce>,
-	GetConfirmationFee: Get<RingBalance<T, FI>>,
 	RootAccount: Get<Option<T::AccountId>>,
 {
 	type Error = &'static str;

--- a/frame/fee-market/src/s2s/payment.rs
+++ b/frame/fee-market/src/s2s/payment.rs
@@ -33,6 +33,8 @@ use sp_std::{
 // --- darwinia-network ---
 use crate::{Config, Orders, Pallet, *};
 
+// TODO: Do we need to add another generic param, I2?
+// It's because the current I refers to pallet_bridge_message's instance
 pub struct FeeMarketPayment<T, I, Currency, GetConfirmationFee, RootAccount> {
 	_phantom: sp_std::marker::PhantomData<(T, I, Currency, GetConfirmationFee, RootAccount)>,
 }

--- a/frame/fee-market/src/s2s/payment.rs
+++ b/frame/fee-market/src/s2s/payment.rs
@@ -33,28 +33,23 @@ use sp_std::{
 // --- darwinia-network ---
 use crate::{Config, Orders, Pallet, *};
 
-// TODO: Do we need to add another generic param, I2?
-// It's because the current I refers to pallet_bridge_message's instance
-pub struct FeeMarketPayment<T, BMI, FI, Currency, RootAccount> {
-	_phantom: sp_std::marker::PhantomData<(T, BMI, FI, Currency, RootAccount)>,
+pub struct FeeMarketPayment<T, I, Currency, RootAccount> {
+	_phantom: sp_std::marker::PhantomData<(T, I, Currency, RootAccount)>,
 }
 
-impl<T, BMI, FI, Currency, RootAccount>
-	MessageDeliveryAndDispatchPayment<T::AccountId, RingBalance<T, FI>>
-	for FeeMarketPayment<T, BMI, FI, Currency, RootAccount>
+impl<T, I, Currency, RootAccount> MessageDeliveryAndDispatchPayment<T::AccountId, RingBalance<T, I>>
+	for FeeMarketPayment<T, I, Currency, RootAccount>
 where
-	T: frame_system::Config + pallet_bridge_messages::Config<BMI> + Config<FI>,
-	BMI: 'static,
-	FI: 'static,
-	Currency: CurrencyT<T::AccountId, Balance = T::OutboundMessageFee>,
-	Currency::Balance: From<MessageNonce>,
+	T: frame_system::Config + Config<I>,
+	I: 'static,
+	Currency: CurrencyT<T::AccountId>,
 	RootAccount: Get<Option<T::AccountId>>,
 {
 	type Error = &'static str;
 
 	fn pay_delivery_and_dispatch_fee(
 		submitter: &Sender<T::AccountId>,
-		fee: &RingBalance<T, FI>,
+		fee: &RingBalance<T, I>,
 		relayer_fund_account: &T::AccountId,
 	) -> Result<(), Self::Error> {
 		let root_account = RootAccount::get();
@@ -65,7 +60,7 @@ where
 				.ok_or("Sending messages using Root or None origin is disallowed.")?,
 		};
 
-		<T as Config<FI>>::RingCurrency::transfer(
+		<T as Config<I>>::RingCurrency::transfer(
 			account,
 			relayer_fund_account,
 			*fee,
@@ -87,7 +82,7 @@ where
 			confirmation_relayer_rewards,
 			assigned_relayers_rewards,
 			treasury_total_rewards,
-		} = slash_and_calculate_rewards::<T, BMI, FI>(
+		} = slash_and_calculate_rewards::<T, I>(
 			lane_id,
 			messages_relayers,
 			received_range,
@@ -95,21 +90,21 @@ where
 		);
 
 		// Pay confirmation relayer rewards
-		do_reward::<T, FI>(
+		do_reward::<T, I>(
 			relayer_fund_account,
 			confirmation_relayer,
 			confirmation_relayer_rewards,
 		);
 		// Pay messages relayers rewards
 		for (relayer, reward) in messages_relayers_rewards {
-			do_reward::<T, FI>(relayer_fund_account, &relayer, reward);
+			do_reward::<T, I>(relayer_fund_account, &relayer, reward);
 		}
 		// Pay assign relayer reward
 		for (relayer, reward) in assigned_relayers_rewards {
-			do_reward::<T, FI>(relayer_fund_account, &relayer, reward);
+			do_reward::<T, I>(relayer_fund_account, &relayer, reward);
 		}
 		// Pay treasury reward
-		do_reward::<T, FI>(
+		do_reward::<T, I>(
 			relayer_fund_account,
 			&T::TreasuryPalletId::get().into_account(),
 			treasury_total_rewards,
@@ -118,21 +113,20 @@ where
 }
 
 /// Slash and calculate rewards for messages_relayers, confirmation relayers, treasury, assigned_relayers
-pub fn slash_and_calculate_rewards<T, BMI, FI>(
+pub fn slash_and_calculate_rewards<T, I>(
 	lane_id: LaneId,
 	messages_relayers: VecDeque<UnrewardedRelayer<T::AccountId>>,
 	received_range: &RangeInclusive<MessageNonce>,
 	relayer_fund_account: &T::AccountId,
-) -> RewardsBook<T::AccountId, RingBalance<T, FI>>
+) -> RewardsBook<T::AccountId, RingBalance<T, I>>
 where
-	T: frame_system::Config + pallet_bridge_messages::Config<BMI> + Config<FI>,
-	BMI: 'static,
-	FI: 'static,
+	T: frame_system::Config + Config<I>,
+	I: 'static,
 {
-	let mut confirmation_rewards = RingBalance::<T, FI>::zero();
-	let mut messages_rewards = BTreeMap::<T::AccountId, RingBalance<T, FI>>::new();
-	let mut assigned_relayers_rewards = BTreeMap::<T::AccountId, RingBalance<T, FI>>::new();
-	let mut treasury_total_rewards = RingBalance::<T, FI>::zero();
+	let mut confirmation_rewards = RingBalance::<T, I>::zero();
+	let mut messages_rewards = BTreeMap::<T::AccountId, RingBalance<T, I>>::new();
+	let mut assigned_relayers_rewards = BTreeMap::<T::AccountId, RingBalance<T, I>>::new();
+	let mut treasury_total_rewards = RingBalance::<T, I>::zero();
 
 	for entry in messages_relayers {
 		let nonce_begin = sp_std::cmp::max(entry.messages.begin, *received_range.start());
@@ -140,7 +134,7 @@ where
 
 		for message_nonce in nonce_begin..nonce_end + 1 {
 			// The order created when message was accepted, so we can always get the order info below.
-			if let Some(order) = <Orders<T, FI>>::get(&(lane_id, message_nonce)) {
+			if let Some(order) = <Orders<T, I>>::get(&(lane_id, message_nonce)) {
 				// The confirm_time of the order is set in the `OnDeliveryConfirmed` callback. And the callback function
 				// was called as source chain received message delivery proof, before the reward payment.
 				let order_confirm_time = order
@@ -176,19 +170,19 @@ where
 					let mut total_slash = message_fee;
 
 					// calculate slash amount
-					let mut amount: RingBalance<T, FI> = T::Slasher::slash(
+					let mut amount: RingBalance<T, I> = T::Slasher::slash(
 						order.locked_collateral,
 						order.delivery_delay().unwrap_or_default(),
 					);
-					if let Some(slash_protect) = Pallet::<T, FI>::collateral_slash_protect() {
+					if let Some(slash_protect) = Pallet::<T, I>::collateral_slash_protect() {
 						amount = sp_std::cmp::min(amount, slash_protect);
 					}
 
 					// Slash order's assigned relayers
-					let mut assigned_relayers_slash = RingBalance::<T, FI>::zero();
+					let mut assigned_relayers_slash = RingBalance::<T, I>::zero();
 					for assigned_relayer in order.relayers_slice() {
 						let report = SlashReport::new(&order, assigned_relayer.id.clone(), amount);
-						let slashed = do_slash::<T, FI>(
+						let slashed = do_slash::<T, I>(
 							&assigned_relayer.id,
 							relayer_fund_account,
 							amount,

--- a/frame/fee-market/src/tests.rs
+++ b/frame/fee-market/src/tests.rs
@@ -300,7 +300,7 @@ impl MessageDeliveryAndDispatchPayment<AccountId, TestMessageFee>
 			confirmation_relayer_rewards,
 			assigned_relayers_rewards,
 			treasury_total_rewards,
-		} = slash_and_calculate_rewards::<Test, (), ()>(
+		} = slash_and_calculate_rewards::<Test, ()>(
 			lane_id,
 			message_relayers,
 			received_range,

--- a/frame/fee-market/src/tests.rs
+++ b/frame/fee-market/src/tests.rs
@@ -414,8 +414,8 @@ impl pallet_bridge_messages::Config for Test {
 	type TargetHeaderChain = TestTargetHeaderChain;
 	type LaneMessageVerifier = TestLaneMessageVerifier;
 	type MessageDeliveryAndDispatchPayment = TestMessageDeliveryAndDispatchPayment;
-	type OnMessageAccepted = FeeMarketMessageAcceptedHandler<Self>;
-	type OnDeliveryConfirmed = FeeMarketMessageConfirmedHandler<Self>;
+	type OnMessageAccepted = FeeMarketMessageAcceptedHandler<Self, ()>;
+	type OnDeliveryConfirmed = FeeMarketMessageConfirmedHandler<Self, ()>;
 
 	type SourceHeaderChain = TestSourceHeaderChain;
 	type MessageDispatch = TestMessageDispatch;

--- a/frame/fee-market/src/tests.rs
+++ b/frame/fee-market/src/tests.rs
@@ -437,8 +437,8 @@ frame_support::parameter_types! {
 }
 
 pub struct TestSlasher;
-impl<T: Config> Slasher<T> for TestSlasher {
-	fn slash(locked_collateral: RingBalance<T>, timeout: T::BlockNumber) -> RingBalance<T> {
+impl<T: Config<I>, I: 'static> Slasher<T, I> for TestSlasher {
+	fn slash(locked_collateral: RingBalance<T, I>, timeout: T::BlockNumber) -> RingBalance<T, I> {
 		let slash_each_block = 2;
 		let slash_value = UniqueSaturatedInto::<u128>::unique_saturated_into(timeout)
 			.saturating_mul(UniqueSaturatedInto::<u128>::unique_saturated_into(

--- a/frame/fee-market/src/tests.rs
+++ b/frame/fee-market/src/tests.rs
@@ -300,7 +300,7 @@ impl MessageDeliveryAndDispatchPayment<AccountId, TestMessageFee>
 			confirmation_relayer_rewards,
 			assigned_relayers_rewards,
 			treasury_total_rewards,
-		} = slash_and_calculate_rewards::<Test, ()>(
+		} = slash_and_calculate_rewards::<Test, (), ()>(
 			lane_id,
 			message_relayers,
 			received_range,

--- a/node/runtime/common/src/impls.rs
+++ b/node/runtime/common/src/impls.rs
@@ -135,18 +135,19 @@ impl Get<Option<(usize, ExtendedBalance)>> for OffchainRandomBalancing {
 ///   dispatch origin;
 /// - check that the sender has paid enough funds for both message delivery and dispatch.
 #[derive(RuntimeDebug)]
-pub struct FromThisChainMessageVerifier<B, R>(PhantomData<(B, R)>);
-impl<B, R>
+pub struct FromThisChainMessageVerifier<B, R, I>(PhantomData<(B, R, I)>);
+impl<B, R, I>
 	LaneMessageVerifier<
 		AccountIdOf<ThisChain<B>>,
 		FromThisChainMessagePayload<B>,
 		BalanceOf<ThisChain<B>>,
-	> for FromThisChainMessageVerifier<B, R>
+	> for FromThisChainMessageVerifier<B, R, I>
 where
 	B: MessageBridge,
-	R: darwinia_fee_market::Config,
+	R: darwinia_fee_market::Config<I>,
+	I: 'static,
 	AccountIdOf<ThisChain<B>>: Clone + PartialEq,
-	darwinia_fee_market::RingBalance<R>: From<BalanceOf<ThisChain<B>>>,
+	darwinia_fee_market::RingBalance<R, I>: From<BalanceOf<ThisChain<B>>>,
 {
 	type Error = &'static str;
 
@@ -178,8 +179,8 @@ where
 
 		// Do the delivery_and_dispatch_fee. We assume that the delivery and dispatch fee always
 		// greater than the fee market provided fee.
-		if let Some(market_fee) = darwinia_fee_market::Pallet::<R>::market_fee() {
-			let message_fee: darwinia_fee_market::RingBalance<R> =
+		if let Some(market_fee) = darwinia_fee_market::Pallet::<R, I>::market_fee() {
+			let message_fee: darwinia_fee_market::RingBalance<R, I> =
 				(*delivery_and_dispatch_fee).into();
 
 			// compare with actual fee paid

--- a/node/runtime/pangolin/src/bridges_message/pangoro.rs
+++ b/node/runtime/pangolin/src/bridges_message/pangoro.rs
@@ -34,7 +34,8 @@ pub type ToPangoroMessagePayload = FromThisChainMessagePayload<WithPangoroMessag
 pub type FromPangoroMessagePayload = FromBridgedChainMessagePayload<WithPangoroMessageBridge>;
 
 /// Message verifier for Pangolin -> Pangoro messages.
-pub type ToPangoroMessageVerifier<R, I> = FromThisChainMessageVerifier<WithPangoroMessageBridge, R, I>;
+pub type ToPangoroMessageVerifier<R, I> =
+	FromThisChainMessageVerifier<WithPangoroMessageBridge, R, I>;
 
 /// Encoded Pangolin Call as it comes from Pangoro.
 pub type FromPangoroEncodedCall = FromBridgedChainEncodedMessageCall<crate::Call>;

--- a/node/runtime/pangolin/src/bridges_message/pangoro.rs
+++ b/node/runtime/pangolin/src/bridges_message/pangoro.rs
@@ -34,7 +34,7 @@ pub type ToPangoroMessagePayload = FromThisChainMessagePayload<WithPangoroMessag
 pub type FromPangoroMessagePayload = FromBridgedChainMessagePayload<WithPangoroMessageBridge>;
 
 /// Message verifier for Pangolin -> Pangoro messages.
-pub type ToPangoroMessageVerifier<R> = FromThisChainMessageVerifier<WithPangoroMessageBridge, R>;
+pub type ToPangoroMessageVerifier<R, I> = FromThisChainMessageVerifier<WithPangoroMessageBridge, R, I>;
 
 /// Encoded Pangolin Call as it comes from Pangoro.
 pub type FromPangoroEncodedCall = FromBridgedChainEncodedMessageCall<crate::Call>;

--- a/node/runtime/pangolin/src/lib.rs
+++ b/node/runtime/pangolin/src/lib.rs
@@ -242,7 +242,8 @@ frame_support::construct_runtime! {
 		BridgeRococoGrandpa: pallet_bridge_grandpa::<Instance2>::{Pallet, Call, Storage} = 60,
 		BridgeRococoParachains: pallet_bridge_parachains::<Instance1>::{Pallet, Call, Storage} = 61,
 
-		FeeMarket: darwinia_fee_market::{Pallet, Call, Storage, Event<T>} = 53,
+		FeeMarket: darwinia_fee_market::<Instance1>::{Pallet, Call, Storage, Event<T>} = 53,
+		FeeMarketParachain: darwinia_fee_market::<Instance2>::{Pallet, Call, Storage, Event<T>} = 62,
 		TransactionPause: module_transaction_pause::{Pallet, Call, Storage, Event<T>} = 54,
 
 		Substrate2SubstrateIssuing: from_substrate_issuing::{Pallet, Call, Storage, Config, Event<T>} = 49,
@@ -562,7 +563,7 @@ sp_api::impl_runtime_apis! {
 	}
 
 	impl darwinia_fee_market_rpc_runtime_api::FeeMarketApi<Block, Balance> for Runtime {
-		fn market_fee() -> Option<darwinia_fee_market_rpc_runtime_api::Fee<Balance>> {
+		fn market_fee(instance: u8) -> Option<darwinia_fee_market_rpc_runtime_api::Fee<Balance>> {
 			if let Some(fee) = FeeMarket::market_fee() {
 				return Some(darwinia_fee_market_rpc_runtime_api::Fee {
 					amount: fee,
@@ -570,7 +571,7 @@ sp_api::impl_runtime_apis! {
 			}
 			None
 		}
-		fn in_process_orders() -> darwinia_fee_market_rpc_runtime_api::InProcessOrders {
+		fn in_process_orders(instance: u8) -> darwinia_fee_market_rpc_runtime_api::InProcessOrders {
 			return darwinia_fee_market_rpc_runtime_api::InProcessOrders {
 				orders: FeeMarket::in_process_orders(),
 			}

--- a/node/runtime/pangolin/src/lib.rs
+++ b/node/runtime/pangolin/src/lib.rs
@@ -242,8 +242,9 @@ frame_support::construct_runtime! {
 		BridgeRococoGrandpa: pallet_bridge_grandpa::<Instance2>::{Pallet, Call, Storage} = 60,
 		BridgeRococoParachains: pallet_bridge_parachains::<Instance1>::{Pallet, Call, Storage} = 61,
 
+		// The fee market instantce1 used for the pangoro network
 		FeeMarket: darwinia_fee_market::<Instance1>::{Pallet, Call, Storage, Event<T>} = 53,
-		FeeMarketParachain: darwinia_fee_market::<Instance2>::{Pallet, Call, Storage, Event<T>} = 62,
+		FeeMarketForParachain: darwinia_fee_market::<Instance2>::{Pallet, Call, Storage, Event<T>} = 62,
 		TransactionPause: module_transaction_pause::{Pallet, Call, Storage, Event<T>} = 54,
 
 		Substrate2SubstrateIssuing: from_substrate_issuing::{Pallet, Call, Storage, Config, Event<T>} = 49,
@@ -566,7 +567,7 @@ sp_api::impl_runtime_apis! {
 		fn market_fee(instance: u8) -> Option<darwinia_fee_market_rpc_runtime_api::Fee<Balance>> {
 			match instance {
 				0 => FeeMarket::market_fee().and_then(|fee| Some(darwinia_fee_market_rpc_runtime_api::Fee { amount: fee })),
-				1 => FeeMarketParachain::market_fee().and_then(|fee| Some(darwinia_fee_market_rpc_runtime_api::Fee { amount: fee })),
+				1 => FeeMarketForParachain::market_fee().and_then(|fee| Some(darwinia_fee_market_rpc_runtime_api::Fee { amount: fee })),
 				_ => None,
 			}
 		}
@@ -576,7 +577,7 @@ sp_api::impl_runtime_apis! {
 					orders: FeeMarket::in_process_orders(),
 				},
 				1 => darwinia_fee_market_rpc_runtime_api::InProcessOrders {
-					orders: FeeMarketParachain::in_process_orders(),
+					orders: FeeMarketForParachain::in_process_orders(),
 				},
 				_ => Default::default()
 			}

--- a/node/runtime/pangolin/src/lib.rs
+++ b/node/runtime/pangolin/src/lib.rs
@@ -565,22 +565,8 @@ sp_api::impl_runtime_apis! {
 	impl darwinia_fee_market_rpc_runtime_api::FeeMarketApi<Block, Balance> for Runtime {
 		fn market_fee(instance: u8) -> Option<darwinia_fee_market_rpc_runtime_api::Fee<Balance>> {
 			match instance {
-				0 => {
-					if let Some(fee) = FeeMarket::market_fee() {
-						return Some(darwinia_fee_market_rpc_runtime_api::Fee {
-							amount: fee,
-						});
-					}
-					None
-				},
-				1 => {
-					if let Some(fee) = FeeMarketParachain::market_fee() {
-						return Some(darwinia_fee_market_rpc_runtime_api::Fee {
-							amount: fee,
-						});
-					}
-					None
-				},
+				0 => FeeMarket::market_fee().and_then(|fee| Some(darwinia_fee_market_rpc_runtime_api::Fee { amount: fee })),
+				1 => FeeMarketParachain::market_fee().and_then(|fee| Some(darwinia_fee_market_rpc_runtime_api::Fee { amount: fee })),
 				_ => None,
 			}
 		}

--- a/node/runtime/pangolin/src/lib.rs
+++ b/node/runtime/pangolin/src/lib.rs
@@ -564,16 +564,35 @@ sp_api::impl_runtime_apis! {
 
 	impl darwinia_fee_market_rpc_runtime_api::FeeMarketApi<Block, Balance> for Runtime {
 		fn market_fee(instance: u8) -> Option<darwinia_fee_market_rpc_runtime_api::Fee<Balance>> {
-			if let Some(fee) = FeeMarket::market_fee() {
-				return Some(darwinia_fee_market_rpc_runtime_api::Fee {
-					amount: fee,
-				});
+			match instance {
+				0 => {
+					if let Some(fee) = FeeMarket::market_fee() {
+						return Some(darwinia_fee_market_rpc_runtime_api::Fee {
+							amount: fee,
+						});
+					}
+					None
+				},
+				1 => {
+					if let Some(fee) = FeeMarketParachain::market_fee() {
+						return Some(darwinia_fee_market_rpc_runtime_api::Fee {
+							amount: fee,
+						});
+					}
+					None
+				},
+				_ => None,
 			}
-			None
 		}
 		fn in_process_orders(instance: u8) -> darwinia_fee_market_rpc_runtime_api::InProcessOrders {
-			return darwinia_fee_market_rpc_runtime_api::InProcessOrders {
-				orders: FeeMarket::in_process_orders(),
+			match instance {
+				0 => darwinia_fee_market_rpc_runtime_api::InProcessOrders {
+					orders: FeeMarket::in_process_orders(),
+				},
+				1 => darwinia_fee_market_rpc_runtime_api::InProcessOrders {
+					orders: FeeMarketParachain::in_process_orders(),
+				},
+				_ => Default::default()
 			}
 		}
 	}

--- a/node/runtime/pangolin/src/lib.rs
+++ b/node/runtime/pangolin/src/lib.rs
@@ -244,7 +244,7 @@ frame_support::construct_runtime! {
 
 		// The fee market instantce1 used for the pangoro network
 		FeeMarket: darwinia_fee_market::<Instance1>::{Pallet, Call, Storage, Event<T>} = 53,
-		FeeMarketForParachain: darwinia_fee_market::<Instance2>::{Pallet, Call, Storage, Event<T>} = 62,
+		WithParachainFeeMarket: darwinia_fee_market::<Instance2>::{Pallet, Call, Storage, Event<T>} = 62,
 		TransactionPause: module_transaction_pause::{Pallet, Call, Storage, Event<T>} = 54,
 
 		Substrate2SubstrateIssuing: from_substrate_issuing::{Pallet, Call, Storage, Config, Event<T>} = 49,
@@ -567,7 +567,7 @@ sp_api::impl_runtime_apis! {
 		fn market_fee(instance: u8) -> Option<darwinia_fee_market_rpc_runtime_api::Fee<Balance>> {
 			match instance {
 				0 => FeeMarket::market_fee().and_then(|fee| Some(darwinia_fee_market_rpc_runtime_api::Fee { amount: fee })),
-				1 => FeeMarketForParachain::market_fee().and_then(|fee| Some(darwinia_fee_market_rpc_runtime_api::Fee { amount: fee })),
+				1 => WithParachainFeeMarket::market_fee().and_then(|fee| Some(darwinia_fee_market_rpc_runtime_api::Fee { amount: fee })),
 				_ => None,
 			}
 		}
@@ -577,7 +577,7 @@ sp_api::impl_runtime_apis! {
 					orders: FeeMarket::in_process_orders(),
 				},
 				1 => darwinia_fee_market_rpc_runtime_api::InProcessOrders {
-					orders: FeeMarketForParachain::in_process_orders(),
+					orders: WithParachainFeeMarket::in_process_orders(),
 				},
 				_ => Default::default()
 			}

--- a/node/runtime/pangolin/src/pallets/bridge_messages.rs
+++ b/node/runtime/pangolin/src/pallets/bridge_messages.rs
@@ -41,7 +41,7 @@ impl Config<WithPangoroMessages> for Runtime {
 	type AccountIdConverter = bp_pangolin::AccountIdConverter;
 
 	type TargetHeaderChain = bm_pangoro::Pangoro;
-	type LaneMessageVerifier = bm_pangoro::ToPangoroMessageVerifier<Self>;
+	type LaneMessageVerifier = bm_pangoro::ToPangoroMessageVerifier<Self, FeeMarketPangro>;
 	type MessageDeliveryAndDispatchPayment = FeeMarketPayment<
 		Runtime,
 		WithPangoroMessages,
@@ -50,10 +50,10 @@ impl Config<WithPangoroMessages> for Runtime {
 		RootAccountForPayments,
 	>;
 
-	type OnMessageAccepted = FeeMarketMessageAcceptedHandler<Self>;
+	type OnMessageAccepted = FeeMarketMessageAcceptedHandler<Self, FeeMarketPangro>;
 	type OnDeliveryConfirmed = (
 		Substrate2SubstrateIssuing,
-		FeeMarketMessageConfirmedHandler<Self>,
+		FeeMarketMessageConfirmedHandler<Self, FeeMarketPangro>,
 	);
 
 	type SourceHeaderChain = bm_pangoro::Pangoro;

--- a/node/runtime/pangolin/src/pallets/bridge_messages.rs
+++ b/node/runtime/pangolin/src/pallets/bridge_messages.rs
@@ -41,7 +41,7 @@ impl Config<WithPangoroMessages> for Runtime {
 	type AccountIdConverter = bp_pangolin::AccountIdConverter;
 
 	type TargetHeaderChain = bm_pangoro::Pangoro;
-	type LaneMessageVerifier = bm_pangoro::ToPangoroMessageVerifier<Self, FeeMarketPangro>;
+	type LaneMessageVerifier = bm_pangoro::ToPangoroMessageVerifier<Self, FeeMarketForPangoro>;
 	type MessageDeliveryAndDispatchPayment = FeeMarketPayment<
 		Runtime,
 		// TODO: check this instance
@@ -51,10 +51,10 @@ impl Config<WithPangoroMessages> for Runtime {
 		RootAccountForPayments,
 	>;
 
-	type OnMessageAccepted = FeeMarketMessageAcceptedHandler<Self, FeeMarketPangro>;
+	type OnMessageAccepted = FeeMarketMessageAcceptedHandler<Self, FeeMarketForPangoro>;
 	type OnDeliveryConfirmed = (
 		Substrate2SubstrateIssuing,
-		FeeMarketMessageConfirmedHandler<Self, FeeMarketPangro>,
+		FeeMarketMessageConfirmedHandler<Self, FeeMarketForPangoro>,
 	);
 
 	type SourceHeaderChain = bm_pangoro::Pangoro;

--- a/node/runtime/pangolin/src/pallets/bridge_messages.rs
+++ b/node/runtime/pangolin/src/pallets/bridge_messages.rs
@@ -44,6 +44,7 @@ impl Config<WithPangoroMessages> for Runtime {
 	type LaneMessageVerifier = bm_pangoro::ToPangoroMessageVerifier<Self, FeeMarketPangro>;
 	type MessageDeliveryAndDispatchPayment = FeeMarketPayment<
 		Runtime,
+		// TODO: check this instance
 		WithPangoroMessages,
 		Ring,
 		GetDeliveryConfirmationTransactionFee,

--- a/node/runtime/pangolin/src/pallets/bridge_messages.rs
+++ b/node/runtime/pangolin/src/pallets/bridge_messages.rs
@@ -47,7 +47,6 @@ impl Config<WithPangoroMessages> for Runtime {
 		WithPangoroMessages,
 		FeeMarketForPangoro,
 		Ring,
-		GetDeliveryConfirmationTransactionFee,
 		RootAccountForPayments,
 	>;
 

--- a/node/runtime/pangolin/src/pallets/bridge_messages.rs
+++ b/node/runtime/pangolin/src/pallets/bridge_messages.rs
@@ -41,19 +41,14 @@ impl Config<WithPangoroMessages> for Runtime {
 	type AccountIdConverter = bp_pangolin::AccountIdConverter;
 
 	type TargetHeaderChain = bm_pangoro::Pangoro;
-	type LaneMessageVerifier = bm_pangoro::ToPangoroMessageVerifier<Self, FeeMarketForPangoro>;
-	type MessageDeliveryAndDispatchPayment = FeeMarketPayment<
-		Runtime,
-		WithPangoroMessages,
-		FeeMarketForPangoro,
-		Ring,
-		RootAccountForPayments,
-	>;
+	type LaneMessageVerifier = bm_pangoro::ToPangoroMessageVerifier<Self, WithPangoroFeeMarket>;
+	type MessageDeliveryAndDispatchPayment =
+		FeeMarketPayment<Runtime, WithPangoroFeeMarket, Ring, RootAccountForPayments>;
 
-	type OnMessageAccepted = FeeMarketMessageAcceptedHandler<Self, FeeMarketForPangoro>;
+	type OnMessageAccepted = FeeMarketMessageAcceptedHandler<Self, WithPangoroFeeMarket>;
 	type OnDeliveryConfirmed = (
 		Substrate2SubstrateIssuing,
-		FeeMarketMessageConfirmedHandler<Self, FeeMarketForPangoro>,
+		FeeMarketMessageConfirmedHandler<Self, WithPangoroFeeMarket>,
 	);
 
 	type SourceHeaderChain = bm_pangoro::Pangoro;

--- a/node/runtime/pangolin/src/pallets/bridge_messages.rs
+++ b/node/runtime/pangolin/src/pallets/bridge_messages.rs
@@ -44,8 +44,8 @@ impl Config<WithPangoroMessages> for Runtime {
 	type LaneMessageVerifier = bm_pangoro::ToPangoroMessageVerifier<Self, FeeMarketForPangoro>;
 	type MessageDeliveryAndDispatchPayment = FeeMarketPayment<
 		Runtime,
-		// TODO: check this instance
 		WithPangoroMessages,
+		FeeMarketForPangoro,
 		Ring,
 		GetDeliveryConfirmationTransactionFee,
 		RootAccountForPayments,

--- a/node/runtime/pangolin/src/pallets/fee_market.rs
+++ b/node/runtime/pangolin/src/pallets/fee_market.rs
@@ -1,3 +1,5 @@
+pub use darwinia_fee_market::{Instance1 as FeeMarketPangro, Instance2 as FeeMarketParachain};
+
 // --- core ---
 use core::cmp;
 // --- substrate ---
@@ -8,8 +10,8 @@ use crate::*;
 use darwinia_fee_market::{Config, RingBalance, Slasher};
 
 pub struct FeeMarketSlasher;
-impl<T: Config> Slasher<T> for FeeMarketSlasher {
-	fn slash(locked_collateral: RingBalance<T>, timeout: T::BlockNumber) -> RingBalance<T> {
+impl<T: Config<I>, I: 'static> Slasher<T, I> for FeeMarketSlasher {
+	fn slash(locked_collateral: RingBalance<T, I>, timeout: T::BlockNumber) -> RingBalance<T, I> {
 		let slash_each_block = 2 * COIN;
 		let slash_value = UniqueSaturatedInto::<Balance>::unique_saturated_into(timeout)
 			.saturating_mul(UniqueSaturatedInto::<Balance>::unique_saturated_into(
@@ -35,7 +37,26 @@ frame_support::parameter_types! {
 	pub const ConfirmRelayersRewardRatio: Permill = Permill::from_percent(20);
 }
 
-impl Config for Runtime {
+impl Config<FeeMarketPangro> for Runtime {
+	type PalletId = FeeMarketPalletId;
+	type TreasuryPalletId = TreasuryPalletId;
+	type LockId = FeeMarketLockId;
+
+	type MinimumRelayFee = MinimumRelayFee;
+	type CollateralPerOrder = CollateralPerOrder;
+	type Slot = Slot;
+
+	type AssignedRelayersRewardRatio = AssignedRelayersRewardRatio;
+	type MessageRelayersRewardRatio = MessageRelayersRewardRatio;
+	type ConfirmRelayersRewardRatio = ConfirmRelayersRewardRatio;
+
+	type Slasher = FeeMarketSlasher;
+	type RingCurrency = Ring;
+	type Event = Event;
+	type WeightInfo = ();
+}
+
+impl Config<FeeMarketParachain> for Runtime {
 	type PalletId = FeeMarketPalletId;
 	type TreasuryPalletId = TreasuryPalletId;
 	type LockId = FeeMarketLockId;

--- a/node/runtime/pangolin/src/pallets/fee_market.rs
+++ b/node/runtime/pangolin/src/pallets/fee_market.rs
@@ -11,7 +11,6 @@ use sp_runtime::{traits::UniqueSaturatedInto, Permill};
 use crate::*;
 use darwinia_fee_market::{Config, RingBalance, Slasher};
 
-// TODO: move this into pallet
 pub struct FeeMarketSlasher;
 impl<T: Config<I>, I: 'static> Slasher<T, I> for FeeMarketSlasher {
 	fn slash(locked_collateral: RingBalance<T, I>, timeout: T::BlockNumber) -> RingBalance<T, I> {
@@ -29,11 +28,11 @@ impl<T: Config<I>, I: 'static> Slasher<T, I> for FeeMarketSlasher {
 frame_support::parameter_types! {
 	pub const TreasuryPalletId: PalletId = PalletId(*b"da/trsry");
 
-	pub const FeeMarketPangoroPalletId: PalletId = PalletId(*b"da/feemk");
-	pub const FeeMarketParachainPalletId: PalletId = PalletId(*b"da/parai");
+	pub const WithPangoroFeeMarketId: PalletId = PalletId(*b"da/feemk");
+	pub const WithParachainFeeMarketId: PalletId = PalletId(*b"da/feepa");
 
-	pub const FeeMarketPangoroLockId: LockIdentifier = *b"da/feelf";
-	pub const FeeMarketParachainLockId: LockIdentifier = *b"da/feepa";
+	pub const WithPangoroFeeMarketLockId: LockIdentifier = *b"da/feelf";
+	pub const WithParachainFeeMarketLockId: LockIdentifier = *b"da/feepa";
 
 	pub const MinimumRelayFee: Balance = 15 * COIN;
 	pub const CollateralPerOrder: Balance = 50 * COIN;
@@ -45,9 +44,10 @@ frame_support::parameter_types! {
 }
 
 impl Config<WithPangoroFeeMarket> for Runtime {
-	type PalletId = FeeMarketPangoroPalletId;
 	type TreasuryPalletId = TreasuryPalletId;
-	type LockId = FeeMarketPangoroLockId;
+
+	type PalletId = WithPangoroFeeMarketId;
+	type LockId = WithPangoroFeeMarketLockId;
 
 	type MinimumRelayFee = MinimumRelayFee;
 	type CollateralPerOrder = CollateralPerOrder;
@@ -64,9 +64,10 @@ impl Config<WithPangoroFeeMarket> for Runtime {
 }
 
 impl Config<WithParachainFeeMarket> for Runtime {
-	type PalletId = FeeMarketParachainPalletId;
 	type TreasuryPalletId = TreasuryPalletId;
-	type LockId = FeeMarketParachainLockId;
+
+	type PalletId = WithParachainFeeMarketId;
+	type LockId = WithParachainFeeMarketLockId;
 
 	type MinimumRelayFee = MinimumRelayFee;
 	type CollateralPerOrder = CollateralPerOrder;

--- a/node/runtime/pangolin/src/pallets/fee_market.rs
+++ b/node/runtime/pangolin/src/pallets/fee_market.rs
@@ -9,6 +9,7 @@ use sp_runtime::{traits::UniqueSaturatedInto, Permill};
 use crate::*;
 use darwinia_fee_market::{Config, RingBalance, Slasher};
 
+// TODO: move this into pallet
 pub struct FeeMarketSlasher;
 impl<T: Config<I>, I: 'static> Slasher<T, I> for FeeMarketSlasher {
 	fn slash(locked_collateral: RingBalance<T, I>, timeout: T::BlockNumber) -> RingBalance<T, I> {
@@ -24,9 +25,13 @@ impl<T: Config<I>, I: 'static> Slasher<T, I> for FeeMarketSlasher {
 }
 
 frame_support::parameter_types! {
-	pub const FeeMarketPalletId: PalletId = PalletId(*b"da/feemk");
 	pub const TreasuryPalletId: PalletId = PalletId(*b"da/trsry");
-	pub const FeeMarketLockId: LockIdentifier = *b"da/feelf";
+
+	pub const FeeMarketPangoroPalletId: PalletId = PalletId(*b"da/feemk");
+	pub const FeeMarketParachainPalletId: PalletId = PalletId(*b"da/parai");
+
+	pub const FeeMarketPangoroLockId: LockIdentifier = *b"da/feelf";
+	pub const FeeMarketParachainLockId: LockIdentifier = *b"da/feepa";
 
 	pub const MinimumRelayFee: Balance = 15 * COIN;
 	pub const CollateralPerOrder: Balance = 50 * COIN;
@@ -38,9 +43,9 @@ frame_support::parameter_types! {
 }
 
 impl Config<FeeMarketPangro> for Runtime {
-	type PalletId = FeeMarketPalletId;
+	type PalletId = FeeMarketPangoroPalletId;
 	type TreasuryPalletId = TreasuryPalletId;
-	type LockId = FeeMarketLockId;
+	type LockId = FeeMarketPangoroLockId;
 
 	type MinimumRelayFee = MinimumRelayFee;
 	type CollateralPerOrder = CollateralPerOrder;
@@ -57,9 +62,9 @@ impl Config<FeeMarketPangro> for Runtime {
 }
 
 impl Config<FeeMarketParachain> for Runtime {
-	type PalletId = FeeMarketPalletId;
+	type PalletId = FeeMarketParachainPalletId;
 	type TreasuryPalletId = TreasuryPalletId;
-	type LockId = FeeMarketLockId;
+	type LockId = FeeMarketParachainLockId;
 
 	type MinimumRelayFee = MinimumRelayFee;
 	type CollateralPerOrder = CollateralPerOrder;

--- a/node/runtime/pangolin/src/pallets/fee_market.rs
+++ b/node/runtime/pangolin/src/pallets/fee_market.rs
@@ -1,4 +1,6 @@
-pub use darwinia_fee_market::{Instance1 as FeeMarketPangro, Instance2 as FeeMarketParachain};
+pub use darwinia_fee_market::{
+	Instance1 as FeeMarketForPangoro, Instance2 as FeeMarketForParachain,
+};
 
 // --- core ---
 use core::cmp;
@@ -42,7 +44,7 @@ frame_support::parameter_types! {
 	pub const ConfirmRelayersRewardRatio: Permill = Permill::from_percent(20);
 }
 
-impl Config<FeeMarketPangro> for Runtime {
+impl Config<FeeMarketForPangoro> for Runtime {
 	type PalletId = FeeMarketPangoroPalletId;
 	type TreasuryPalletId = TreasuryPalletId;
 	type LockId = FeeMarketPangoroLockId;
@@ -61,7 +63,7 @@ impl Config<FeeMarketPangro> for Runtime {
 	type WeightInfo = ();
 }
 
-impl Config<FeeMarketParachain> for Runtime {
+impl Config<FeeMarketForParachain> for Runtime {
 	type PalletId = FeeMarketParachainPalletId;
 	type TreasuryPalletId = TreasuryPalletId;
 	type LockId = FeeMarketParachainLockId;

--- a/node/runtime/pangolin/src/pallets/fee_market.rs
+++ b/node/runtime/pangolin/src/pallets/fee_market.rs
@@ -1,5 +1,5 @@
 pub use darwinia_fee_market::{
-	Instance1 as FeeMarketForPangoro, Instance2 as FeeMarketForParachain,
+	Instance1 as WithPangoroFeeMarket, Instance2 as WithParachainFeeMarket,
 };
 
 // --- core ---
@@ -44,7 +44,7 @@ frame_support::parameter_types! {
 	pub const ConfirmRelayersRewardRatio: Permill = Permill::from_percent(20);
 }
 
-impl Config<FeeMarketForPangoro> for Runtime {
+impl Config<WithPangoroFeeMarket> for Runtime {
 	type PalletId = FeeMarketPangoroPalletId;
 	type TreasuryPalletId = TreasuryPalletId;
 	type LockId = FeeMarketPangoroLockId;
@@ -63,7 +63,7 @@ impl Config<FeeMarketForPangoro> for Runtime {
 	type WeightInfo = ();
 }
 
-impl Config<FeeMarketForParachain> for Runtime {
+impl Config<WithParachainFeeMarket> for Runtime {
 	type PalletId = FeeMarketParachainPalletId;
 	type TreasuryPalletId = TreasuryPalletId;
 	type LockId = FeeMarketParachainLockId;

--- a/node/runtime/pangoro/src/bridges_message/pangolin.rs
+++ b/node/runtime/pangoro/src/bridges_message/pangolin.rs
@@ -36,7 +36,8 @@ pub type ToPangolinMessagePayload = FromThisChainMessagePayload<WithPangolinMess
 pub type FromPangolinMessagePayload = FromBridgedChainMessagePayload<WithPangolinMessageBridge>;
 
 /// Message verifier for Pangoro -> Pangolin messages.
-pub type ToPangolinMessageVerifier<R> = FromThisChainMessageVerifier<WithPangolinMessageBridge, R>;
+pub type ToPangolinMessageVerifier<R, I> =
+	FromThisChainMessageVerifier<WithPangolinMessageBridge, R, I>;
 
 /// Encoded Pangoro Call as it comes from Pangolin.
 pub type FromPangolinEncodedCall = FromBridgedChainEncodedMessageCall<Call>;

--- a/node/runtime/pangoro/src/lib.rs
+++ b/node/runtime/pangoro/src/lib.rs
@@ -153,7 +153,7 @@ frame_support::construct_runtime!(
 		BridgePangolinGrandpa: pallet_bridge_grandpa::<Instance1>::{Pallet, Call, Storage} = 19,
 		BridgePangolinMessages: pallet_bridge_messages::<Instance1>::{Pallet, Call, Storage, Event<T>} = 17,
 
-		FeeMarket: darwinia_fee_market::{Pallet, Call, Storage, Event<T>} = 22,
+		FeeMarket: darwinia_fee_market::<Instance1>::{Pallet, Call, Storage, Event<T>} = 22,
 		TransactionPause: module_transaction_pause::{Pallet, Call, Storage, Event<T>} = 23,
 
 		Substrate2SubstrateBacking: to_substrate_backing::{Pallet, Call, Storage, Config<T>, Event<T>} = 20,
@@ -476,7 +476,7 @@ sp_api::impl_runtime_apis! {
 	}
 
 	impl darwinia_fee_market_rpc_runtime_api::FeeMarketApi<Block, Balance> for Runtime {
-		fn market_fee() -> Option<darwinia_fee_market_rpc_runtime_api::Fee<Balance>> {
+		fn market_fee(_instance: u8) -> Option<darwinia_fee_market_rpc_runtime_api::Fee<Balance>> {
 			if let Some(fee) = FeeMarket::market_fee() {
 				return Some(darwinia_fee_market_rpc_runtime_api::Fee {
 					amount: fee,
@@ -485,7 +485,7 @@ sp_api::impl_runtime_apis! {
 			None
 		}
 
-		fn in_process_orders() -> darwinia_fee_market_rpc_runtime_api::InProcessOrders {
+		fn in_process_orders(_instance: u8) -> darwinia_fee_market_rpc_runtime_api::InProcessOrders {
 			return darwinia_fee_market_rpc_runtime_api::InProcessOrders {
 				orders: FeeMarket::in_process_orders(),
 			}

--- a/node/runtime/pangoro/src/lib.rs
+++ b/node/runtime/pangoro/src/lib.rs
@@ -475,18 +475,14 @@ sp_api::impl_runtime_apis! {
 		}
 	}
 
+	// The pangoro network has only one FeeMarket pallet instance right now.
 	impl darwinia_fee_market_rpc_runtime_api::FeeMarketApi<Block, Balance> for Runtime {
 		fn market_fee(_instance: u8) -> Option<darwinia_fee_market_rpc_runtime_api::Fee<Balance>> {
-			if let Some(fee) = FeeMarket::market_fee() {
-				return Some(darwinia_fee_market_rpc_runtime_api::Fee {
-					amount: fee,
-				});
-			}
-			None
+			FeeMarket::market_fee().and_then(|fee| Some(darwinia_fee_market_rpc_runtime_api::Fee { amount: fee }))
 		}
 
 		fn in_process_orders(_instance: u8) -> darwinia_fee_market_rpc_runtime_api::InProcessOrders {
-			return darwinia_fee_market_rpc_runtime_api::InProcessOrders {
+			darwinia_fee_market_rpc_runtime_api::InProcessOrders {
 				orders: FeeMarket::in_process_orders(),
 			}
 		}

--- a/node/runtime/pangoro/src/pallets/bridge_messages.rs
+++ b/node/runtime/pangoro/src/pallets/bridge_messages.rs
@@ -41,20 +41,14 @@ impl Config<WithPangolinMessages> for Runtime {
 	type AccountIdConverter = bp_pangoro::AccountIdConverter;
 
 	type TargetHeaderChain = bm_pangolin::Pangolin;
-	type LaneMessageVerifier =
-		bm_pangolin::ToPangolinMessageVerifier<Self, FeeMarketWorkForPangolin>;
-	type MessageDeliveryAndDispatchPayment = FeeMarketPayment<
-		Runtime,
-		WithPangolinMessages,
-		FeeMarketWorkForPangolin,
-		Ring,
-		RootAccountForPayments,
-	>;
+	type LaneMessageVerifier = bm_pangolin::ToPangolinMessageVerifier<Self, WithPangolinFeeMarket>;
+	type MessageDeliveryAndDispatchPayment =
+		FeeMarketPayment<Runtime, WithPangolinFeeMarket, Ring, RootAccountForPayments>;
 
-	type OnMessageAccepted = FeeMarketMessageAcceptedHandler<Self, FeeMarketWorkForPangolin>;
+	type OnMessageAccepted = FeeMarketMessageAcceptedHandler<Self, WithPangolinFeeMarket>;
 	type OnDeliveryConfirmed = (
 		Substrate2SubstrateBacking,
-		FeeMarketMessageConfirmedHandler<Self, FeeMarketWorkForPangolin>,
+		FeeMarketMessageConfirmedHandler<Self, WithPangolinFeeMarket>,
 	);
 
 	type SourceHeaderChain = bm_pangolin::Pangolin;

--- a/node/runtime/pangoro/src/pallets/bridge_messages.rs
+++ b/node/runtime/pangoro/src/pallets/bridge_messages.rs
@@ -41,7 +41,7 @@ impl Config<WithPangolinMessages> for Runtime {
 	type AccountIdConverter = bp_pangoro::AccountIdConverter;
 
 	type TargetHeaderChain = bm_pangolin::Pangolin;
-	type LaneMessageVerifier = bm_pangolin::ToPangolinMessageVerifier<Self>;
+	type LaneMessageVerifier = bm_pangolin::ToPangolinMessageVerifier<Self, FeeMarketPangolin>;
 	type MessageDeliveryAndDispatchPayment = FeeMarketPayment<
 		Runtime,
 		WithPangolinMessages,
@@ -50,10 +50,10 @@ impl Config<WithPangolinMessages> for Runtime {
 		RootAccountForPayments,
 	>;
 
-	type OnMessageAccepted = FeeMarketMessageAcceptedHandler<Self>;
+	type OnMessageAccepted = FeeMarketMessageAcceptedHandler<Self, FeeMarketPangolin>;
 	type OnDeliveryConfirmed = (
 		Substrate2SubstrateBacking,
-		FeeMarketMessageConfirmedHandler<Self>,
+		FeeMarketMessageConfirmedHandler<Self, FeeMarketPangolin>,
 	);
 
 	type SourceHeaderChain = bm_pangolin::Pangolin;

--- a/node/runtime/pangoro/src/pallets/bridge_messages.rs
+++ b/node/runtime/pangoro/src/pallets/bridge_messages.rs
@@ -41,7 +41,8 @@ impl Config<WithPangolinMessages> for Runtime {
 	type AccountIdConverter = bp_pangoro::AccountIdConverter;
 
 	type TargetHeaderChain = bm_pangolin::Pangolin;
-	type LaneMessageVerifier = bm_pangolin::ToPangolinMessageVerifier<Self, FeeMarketPangolin>;
+	type LaneMessageVerifier =
+		bm_pangolin::ToPangolinMessageVerifier<Self, FeeMarketWorkForPangolin>;
 	type MessageDeliveryAndDispatchPayment = FeeMarketPayment<
 		Runtime,
 		WithPangolinMessages,
@@ -50,10 +51,10 @@ impl Config<WithPangolinMessages> for Runtime {
 		RootAccountForPayments,
 	>;
 
-	type OnMessageAccepted = FeeMarketMessageAcceptedHandler<Self, FeeMarketPangolin>;
+	type OnMessageAccepted = FeeMarketMessageAcceptedHandler<Self, FeeMarketWorkForPangolin>;
 	type OnDeliveryConfirmed = (
 		Substrate2SubstrateBacking,
-		FeeMarketMessageConfirmedHandler<Self, FeeMarketPangolin>,
+		FeeMarketMessageConfirmedHandler<Self, FeeMarketWorkForPangolin>,
 	);
 
 	type SourceHeaderChain = bm_pangolin::Pangolin;

--- a/node/runtime/pangoro/src/pallets/bridge_messages.rs
+++ b/node/runtime/pangoro/src/pallets/bridge_messages.rs
@@ -46,6 +46,7 @@ impl Config<WithPangolinMessages> for Runtime {
 	type MessageDeliveryAndDispatchPayment = FeeMarketPayment<
 		Runtime,
 		WithPangolinMessages,
+		FeeMarketWorkForPangolin,
 		Ring,
 		GetDeliveryConfirmationTransactionFee,
 		RootAccountForPayments,

--- a/node/runtime/pangoro/src/pallets/bridge_messages.rs
+++ b/node/runtime/pangoro/src/pallets/bridge_messages.rs
@@ -48,7 +48,6 @@ impl Config<WithPangolinMessages> for Runtime {
 		WithPangolinMessages,
 		FeeMarketWorkForPangolin,
 		Ring,
-		GetDeliveryConfirmationTransactionFee,
 		RootAccountForPayments,
 	>;
 

--- a/node/runtime/pangoro/src/pallets/fee_market.rs
+++ b/node/runtime/pangoro/src/pallets/fee_market.rs
@@ -1,4 +1,4 @@
-pub use darwinia_fee_market::Instance1 as FeeMarketWorkForPangolin;
+pub use darwinia_fee_market::Instance1 as WithPangolinFeeMarket;
 // --- core ---
 use core::cmp;
 // --- substrate ---
@@ -36,7 +36,7 @@ frame_support::parameter_types! {
 	pub const ConfirmRelayersRewardRatio: Permill = Permill::from_percent(20);
 }
 
-impl Config<FeeMarketWorkForPangolin> for Runtime {
+impl Config<WithPangolinFeeMarket> for Runtime {
 	type PalletId = FeeMarketPalletId;
 	type TreasuryPalletId = TreasuryPalletId;
 	type LockId = FeeMarketLockId;

--- a/node/runtime/pangoro/src/pallets/fee_market.rs
+++ b/node/runtime/pangoro/src/pallets/fee_market.rs
@@ -1,4 +1,4 @@
-pub use darwinia_fee_market::Instance1 as FeeMarketPangolin;
+pub use darwinia_fee_market::Instance1 as FeeMarketWorkForPangolin;
 // --- core ---
 use core::cmp;
 // --- substrate ---
@@ -36,7 +36,7 @@ frame_support::parameter_types! {
 	pub const ConfirmRelayersRewardRatio: Permill = Permill::from_percent(20);
 }
 
-impl Config<FeeMarketPangolin> for Runtime {
+impl Config<FeeMarketWorkForPangolin> for Runtime {
 	type PalletId = FeeMarketPalletId;
 	type TreasuryPalletId = TreasuryPalletId;
 	type LockId = FeeMarketLockId;

--- a/node/runtime/pangoro/src/pallets/fee_market.rs
+++ b/node/runtime/pangoro/src/pallets/fee_market.rs
@@ -1,3 +1,4 @@
+pub use darwinia_fee_market::Instance1 as FeeMarketPangolin;
 // --- core ---
 use core::cmp;
 // --- substrate ---
@@ -8,8 +9,8 @@ use crate::*;
 use darwinia_fee_market::{Config, RingBalance, Slasher};
 
 pub struct FeeMarketSlasher;
-impl<T: Config> Slasher<T> for FeeMarketSlasher {
-	fn slash(locked_collateral: RingBalance<T>, timeout: T::BlockNumber) -> RingBalance<T> {
+impl<T: Config<I>, I: 'static> Slasher<T, I> for FeeMarketSlasher {
+	fn slash(locked_collateral: RingBalance<T, I>, timeout: T::BlockNumber) -> RingBalance<T, I> {
 		let slash_each_block = 2 * COIN;
 		let slash_value = UniqueSaturatedInto::<Balance>::unique_saturated_into(timeout)
 			.saturating_mul(UniqueSaturatedInto::<Balance>::unique_saturated_into(
@@ -35,7 +36,7 @@ frame_support::parameter_types! {
 	pub const ConfirmRelayersRewardRatio: Permill = Permill::from_percent(20);
 }
 
-impl Config for Runtime {
+impl Config<FeeMarketPangolin> for Runtime {
 	type PalletId = FeeMarketPalletId;
 	type TreasuryPalletId = TreasuryPalletId;
 	type LockId = FeeMarketLockId;


### PR DESCRIPTION
As I didn't change the `locked_id` or `pallet_id ` of the original pangolin<> pangoro fee market config, so no migration needs.

Note: The original fee market runtime API has broken changes, add an extra `instance: u8` param.