### PR TITLE
Revert gas price update

### DIFF
--- a/node/runtime/pangolin/src/pallets/evm.rs
+++ b/node/runtime/pangolin/src/pallets/evm.rs
@@ -145,7 +145,7 @@ where
 pub struct FixedGasPrice;
 impl FeeCalculator for FixedGasPrice {
 	fn min_gas_price() -> U256 {
-		U256::from(10 * GWEI)
+		U256::from(1 * GWEI)
 	}
 }
 

--- a/node/runtime/pangoro/src/pallets/evm.rs
+++ b/node/runtime/pangoro/src/pallets/evm.rs
@@ -86,7 +86,7 @@ where
 pub struct FixedGasPrice;
 impl FeeCalculator for FixedGasPrice {
 	fn min_gas_price() -> U256 {
-		U256::from(10 * GWEI)
+		U256::from(1 * GWEI)
 	}
 }
 

--- a/tests/dvm/darwinia/tests/1-test-transfer.ts
+++ b/tests/dvm/darwinia/tests/1-test-transfer.ts
@@ -40,7 +40,7 @@ describe("Test Transfer Balance", function () {
 		const balanceFrom = web3.utils.fromWei(await web3.eth.getBalance(addressFrom), "ether");
 		const balanceTo = await web3.utils.fromWei(await web3.eth.getBalance(addressTo), "ether");
 
-		expect(balanceFrom).to.be.equal("123446.78879000000000009");
+		expect(balanceFrom).to.be.equal("123446.78897900000000009");
 		expect(balanceTo).to.be.equal("10");
 		expect(await web3.eth.getTransactionCount(addressFrom, "latest")).to.eq(1);
 	});
@@ -64,7 +64,7 @@ describe("Test Transfer Balance", function () {
 		const balanceFrom = web3.utils.fromWei(await web3.eth.getBalance(addressFrom), "ether");
 		const balanceTo = await web3.utils.fromWei(await web3.eth.getBalance(addressTo2), "ether");
 
-		expect(balanceFrom).to.be.equal("123446.78857999999999999");
+		expect(balanceFrom).to.be.equal("123446.78895799999999999");
 		expect(balanceTo).to.be.equal("0.0000000000000001");
 		expect(await web3.eth.getTransactionCount(addressFrom, "latest")).to.eq(2);
 	});
@@ -89,7 +89,7 @@ describe("Test Transfer Balance", function () {
 		const balanceFrom = web3.utils.fromWei(await web3.eth.getBalance(addressFrom), "ether");
 		const balanceTo = await web3.utils.fromWei(await web3.eth.getBalance(addressTo), "ether");
 
-		expect(balanceFrom).to.be.equal("123396.78836999999999999");
+		expect(balanceFrom).to.be.equal("123396.78893699999999999");
 		expect(balanceTo).to.be.equal("60");
 		expect(await web3.eth.getTransactionCount(addressFrom, "latest")).to.eq(3);
 	});
@@ -112,7 +112,7 @@ describe("Test Transfer Balance", function () {
 
 	it("Check balance after transfer self", async function () {
 		const balanceFrom = web3.utils.fromWei(await web3.eth.getBalance(addressFrom), "ether");
-		expect(balanceFrom).to.be.equal("123396.78815999999999999");
+		expect(balanceFrom).to.be.equal("123396.78891599999999999");
 		expect(await web3.eth.getTransactionCount(addressFrom, "latest")).to.eq(4);
 	});
 });

--- a/tests/dvm/darwinia/tests/2-test-log.ts
+++ b/tests/dvm/darwinia/tests/2-test-log.ts
@@ -9,7 +9,7 @@ const account = web3.eth.accounts.wallet.add(config.privKey);
 const jsontest = new web3.eth.Contract(log_test.abi as AbiItem[]);
 jsontest.options.from = config.address;
 jsontest.options.gas = config.gas;
-jsontest.options.gasPrice = "10000000000";
+jsontest.options.gasPrice = "1000000000";
 
 describe("Test Contract Log", function () {
 	it("Deploy json test contract", async function () {

--- a/tests/dvm/darwinia/tests/4-test-opcodes.ts
+++ b/tests/dvm/darwinia/tests/4-test-opcodes.ts
@@ -10,7 +10,7 @@ const account = web3.eth.accounts.wallet.add(config.privKey);
 const opcodes = new web3.eth.Contract(opcodes_test.abi as AbiItem[]);
 opcodes.options.from = config.address;
 opcodes.options.gas = config.gas;
-opcodes.options.gasPrice = "10000000000";
+opcodes.options.gasPrice = "1000000000";
 
 describe("Test Solidity OpCodes", function () {
 	it("Should run without errors the majort of opcodes", async () => {


### PR DESCRIPTION
The auto-filled `max_fee_per_gas` in the metamask is much higher than our newly `gas_price` and causes `InvalidTransaction` error. 