### PR TITLE
Add build_message_payload(...) method to s2s precompile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,7 +685,7 @@ dependencies = [
 [[package]]
 name = "bp-darwinia-core"
 version = "0.1.0"
-source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#5137bc3620015f94d8db5ff84bb2ce0c7a2bba1f"
+source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#f49be557ab4a3dd168d77c0540c3dd2d86940c8a"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -701,7 +701,7 @@ dependencies = [
 [[package]]
 name = "bp-header-chain"
 version = "0.1.0"
-source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#5137bc3620015f94d8db5ff84bb2ce0c7a2bba1f"
+source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#f49be557ab4a3dd168d77c0540c3dd2d86940c8a"
 dependencies = [
  "finality-grandpa",
  "frame-support",
@@ -717,7 +717,7 @@ dependencies = [
 [[package]]
 name = "bp-message-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#5137bc3620015f94d8db5ff84bb2ce0c7a2bba1f"
+source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#f49be557ab4a3dd168d77c0540c3dd2d86940c8a"
 dependencies = [
  "bp-runtime",
  "frame-support",
@@ -729,7 +729,7 @@ dependencies = [
 [[package]]
 name = "bp-messages"
 version = "0.1.0"
-source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#5137bc3620015f94d8db5ff84bb2ce0c7a2bba1f"
+source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#f49be557ab4a3dd168d77c0540c3dd2d86940c8a"
 dependencies = [
  "bitvec 0.20.4",
  "bp-runtime",
@@ -746,7 +746,7 @@ dependencies = [
 [[package]]
 name = "bp-pangolin"
 version = "0.1.0"
-source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#5137bc3620015f94d8db5ff84bb2ce0c7a2bba1f"
+source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#f49be557ab4a3dd168d77c0540c3dd2d86940c8a"
 dependencies = [
  "bp-darwinia-core",
  "bp-messages",
@@ -761,7 +761,7 @@ dependencies = [
 [[package]]
 name = "bp-pangoro"
 version = "0.1.0"
-source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#5137bc3620015f94d8db5ff84bb2ce0c7a2bba1f"
+source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#f49be557ab4a3dd168d77c0540c3dd2d86940c8a"
 dependencies = [
  "bp-darwinia-core",
  "bp-messages",
@@ -776,7 +776,7 @@ dependencies = [
 [[package]]
 name = "bp-parachains"
 version = "0.1.0"
-source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#5137bc3620015f94d8db5ff84bb2ce0c7a2bba1f"
+source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#f49be557ab4a3dd168d77c0540c3dd2d86940c8a"
 dependencies = [
  "bp-polkadot-core",
  "bp-runtime",
@@ -790,7 +790,7 @@ dependencies = [
 [[package]]
 name = "bp-polkadot-core"
 version = "0.1.0"
-source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#5137bc3620015f94d8db5ff84bb2ce0c7a2bba1f"
+source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#f49be557ab4a3dd168d77c0540c3dd2d86940c8a"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -810,7 +810,7 @@ dependencies = [
 [[package]]
 name = "bp-rococo"
 version = "0.1.0"
-source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#5137bc3620015f94d8db5ff84bb2ce0c7a2bba1f"
+source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#f49be557ab4a3dd168d77c0540c3dd2d86940c8a"
 dependencies = [
  "bp-messages",
  "bp-polkadot-core",
@@ -827,7 +827,7 @@ dependencies = [
 [[package]]
 name = "bp-runtime"
 version = "0.1.0"
-source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#5137bc3620015f94d8db5ff84bb2ce0c7a2bba1f"
+source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#f49be557ab4a3dd168d77c0540c3dd2d86940c8a"
 dependencies = [
  "frame-support",
  "hash-db",
@@ -845,7 +845,7 @@ dependencies = [
 [[package]]
 name = "bp-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#5137bc3620015f94d8db5ff84bb2ce0c7a2bba1f"
+source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#f49be557ab4a3dd168d77c0540c3dd2d86940c8a"
 dependencies = [
  "bp-header-chain",
  "ed25519-dalek",
@@ -860,7 +860,7 @@ dependencies = [
 [[package]]
 name = "bridge-runtime-common"
 version = "0.1.0"
-source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#5137bc3620015f94d8db5ff84bb2ce0c7a2bba1f"
+source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#f49be557ab4a3dd168d77c0540c3dd2d86940c8a"
 dependencies = [
  "bp-message-dispatch",
  "bp-messages",
@@ -4392,9 +4392,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+checksum = "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259"
 
 [[package]]
 name = "libloading"
@@ -5982,7 +5982,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#5137bc3620015f94d8db5ff84bb2ce0c7a2bba1f"
+source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#f49be557ab4a3dd168d77c0540c3dd2d86940c8a"
 dependencies = [
  "bp-message-dispatch",
  "bp-runtime",
@@ -5999,7 +5999,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-grandpa"
 version = "0.1.0"
-source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#5137bc3620015f94d8db5ff84bb2ce0c7a2bba1f"
+source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#f49be557ab4a3dd168d77c0540c3dd2d86940c8a"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -6021,7 +6021,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-messages"
 version = "0.1.0"
-source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#5137bc3620015f94d8db5ff84bb2ce0c7a2bba1f"
+source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#f49be557ab4a3dd168d77c0540c3dd2d86940c8a"
 dependencies = [
  "bitvec 0.20.4",
  "bp-message-dispatch",
@@ -6042,7 +6042,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-parachains"
 version = "0.1.0"
-source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#5137bc3620015f94d8db5ff84bb2ce0c7a2bba1f"
+source = "git+https://github.com/darwinia-network/darwinia-bridges-substrate?branch=darwinia-v0.12.1#f49be557ab4a3dd168d77c0540c3dd2d86940c8a"
 dependencies = [
  "bp-parachains",
  "bp-polkadot-core",

--- a/frame/dvm/evm/precompiles/bridge/s2s/src/lib.rs
+++ b/frame/dvm/evm/precompiles/bridge/s2s/src/lib.rs
@@ -54,6 +54,8 @@ enum Action {
 		"encode_unlock_from_remote_dispatch_call(uint32,uint64,uint32,address,bytes,uint256)",
 	EncodeSendMessageDispatchCall =
 		"encode_send_message_dispatch_call(uint32,bytes4,bytes,uint256)",
+	BuildMessagePayload =
+		"build_message_payload(uint32,uint64,bytes)",
 }
 
 /// The contract address: 0000000000000000000000000000000000000018
@@ -88,6 +90,9 @@ where
 			}
 			Action::EncodeSendMessageDispatchCall => {
 				Self::encode_send_message_dispatch_call(&dvm_parser)?
+			}
+			Action::BuildMessagePayload => {
+				Self::build_message_payload(&dvm_parser, context.caller)?
 			}
 		};
 

--- a/primitives/contract/src/mapping_token_factory/s2s.rs
+++ b/primitives/contract/src/mapping_token_factory/s2s.rs
@@ -198,3 +198,54 @@ impl S2sSendMessageParams {
 		}
 	}
 }
+
+/// S2sMessagePayloadInfo
+/// @spec_version: the remote chain's spec_version
+/// @weight: the remote dispatch call's weight
+#[derive(Debug, PartialEq, Eq)]
+pub struct S2sMessagePayloadInfo {
+	pub spec_version: u32,
+	pub weight: u64,
+	pub call: Vec<u8>,
+}
+
+impl S2sMessagePayloadInfo {
+	pub fn abi_encode(
+		spec_version: u32,
+		weight: u64,
+		call: Vec<u8>,
+	) -> Vec<u8> {
+		ethabi::encode(&[
+			Token::Uint(spec_version.into()),
+			Token::Uint(weight.into()),
+			Token::Bytes(call),
+		])
+	}
+
+	pub fn abi_decode(data: &[u8]) -> AbiResult<Self> {
+		let tokens = ethabi::decode(
+			&[
+				ParamType::Uint(32),
+				ParamType::Uint(64),
+				ParamType::Bytes,
+			],
+			&data,
+		)?;
+		match (
+			tokens[0].clone(),
+			tokens[1].clone(),
+			tokens[2].clone()
+		) {
+			(
+				Token::Uint(spec_version),
+				Token::Uint(weight),
+				Token::Bytes(call),
+			) => Ok(Self {
+				spec_version: spec_version.low_u32(),
+				weight: weight.low_u64(),
+				call,
+			}),
+			_ => Err(Error::InvalidData),
+		}
+	}
+}


### PR DESCRIPTION
if you want to do a `smart chain > pallet` remote dispatch_call, the dispatch_call data need to be wrapped with some other information.  The wrapped data is the `message payload`. This is a scale codec process which is hard to do in solidity. So, I add a  `build_message_payload` helper method to the s2s precompile.