### PR TITLE
Remove Incorrect Annotation

### DIFF
--- a/frame/dvm/evm/precompiles/bridge/bsc/src/lib.rs
+++ b/frame/dvm/evm/precompiles/bridge/bsc/src/lib.rs
@@ -48,7 +48,6 @@ enum Action {
 
 const MAX_MULTI_STORAGEKEY_SIZE: usize = 32;
 
-/// The contract address: 0000000000000000000000000000000000000026
 pub struct BscBridge<T> {
 	_marker: PhantomData<T>,
 }

--- a/frame/dvm/evm/precompiles/bridge/ethereum/src/lib.rs
+++ b/frame/dvm/evm/precompiles/bridge/ethereum/src/lib.rs
@@ -36,7 +36,6 @@ enum Action {
 	TokenRegisterResponse = "token_register_response(address,address,address)",
 }
 
-/// The contract address: 0000000000000000000000000000000000000017
 pub struct EthereumBridge<T> {
 	_marker: PhantomData<T>,
 }

--- a/frame/dvm/evm/precompiles/bridge/s2s/src/lib.rs
+++ b/frame/dvm/evm/precompiles/bridge/s2s/src/lib.rs
@@ -55,7 +55,6 @@ enum Action {
 		"encode_send_message_dispatch_call(uint32,bytes4,bytes,uint256)",
 }
 
-/// The contract address: 0000000000000000000000000000000000000018
 pub struct Sub2SubBridge<T, S, P> {
 	_marker: PhantomData<(T, S, P)>,
 }


### PR DESCRIPTION
The precompile address is determined in runtime and varies in different networks. Those fixed annotations here is easy to make newbies confused.