### PR TITLE
Enable `evm-tracing` for Pangoro

### DIFF
--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -102,7 +102,10 @@ fast-runtime = [
 	"pangoro-runtime/fast-runtime",
 ]
 
-evm-tracing = ["pangolin-runtime/evm-tracing"]
+evm-tracing = [
+	"pangolin-runtime/evm-tracing",
+	"pangoro-runtime/evm-tracing",
+]
 
 template = [
 	"drml-rpc/template",


### PR DESCRIPTION
Some contracts are only deployed on the Pangoro network, add tracing runtime support the same with the Pangolin.