### PR TITLE
Update precompiles registered addrs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6319,6 +6319,7 @@ dependencies = [
  "darwinia-ethereum",
  "darwinia-evm",
  "darwinia-evm-precompile-bls12-381",
+ "darwinia-evm-precompile-dispatch",
  "darwinia-evm-precompile-mpt",
  "darwinia-evm-precompile-state-storage",
  "darwinia-evm-precompile-transfer",

--- a/node/runtime/pangolin/src/pallets/evm.rs
+++ b/node/runtime/pangolin/src/pallets/evm.rs
@@ -102,7 +102,7 @@ where
 	}
 
 	pub fn used_addresses() -> sp_std::vec::Vec<H160> {
-		sp_std::vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 21, 23, 24, 25, 27]
+		sp_std::vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 1024, 1025, 21, 23, 24]
 			.into_iter()
 			.map(|x| addr(x))
 			.collect()
@@ -146,10 +146,16 @@ where
 			a if a == addr(7) => Some(Bn128Mul::execute(input, target_gas, context, is_static)),
 			a if a == addr(8) => Some(Bn128Pairing::execute(input, target_gas, context, is_static)),
 			a if a == addr(9) => Some(Blake2F::execute(input, target_gas, context, is_static)),
-			// Darwinia precompiles: 1024+ for stable precompiles, 2048+ for experimental
-			// precompiles
+			// Darwinia precompiles: 1024+ for stable precompiles.
+			// TODO: Change the transfer precompile address after https://github.com/darwinia-network/darwinia-common/issues/1259
 			a if a == addr(21) =>
 				Some(<Transfer<R>>::execute(input, target_gas, context, is_static)),
+			a if a == addr(1024) => Some(<StateStorage<R, StorageFilter>>::execute(
+				input, target_gas, context, is_static,
+			)),
+			a if a == addr(1025) =>
+				Some(<Dispatch<R>>::execute(input, target_gas, context, is_static)),
+			// TODO: Delete EthereumBridge and Sub2SubBridge precompiles in the futures.
 			a if a == addr(23) =>
 				Some(<EthereumBridge<R>>::execute(input, target_gas, context, is_static)),
 			a if a == addr(24) => Some(<Sub2SubBridge<
@@ -157,11 +163,10 @@ where
 				ToPangoroMessageSender,
 				bm_pangoro::ToPangoroOutboundPayLoad,
 			>>::execute(input, target_gas, context, is_static)),
-			a if a == addr(25) =>
-				Some(<Dispatch<R>>::execute(input, target_gas, context, is_static)),
-			a if a == addr(27) => Some(<StateStorage<R, StorageFilter>>::execute(
-				input, target_gas, context, is_static,
-			)),
+			// Darwinia precompiles: 2048+ for experimental precompiles.
+			a if a == addr(2048) =>
+				Some(<BLS12381<R>>::execute(input, target_gas, context, is_static)),
+			a if a == addr(2049) => Some(<MPT<R>>::execute(input, target_gas, context, is_static)),
 			_ => None,
 		}
 	}

--- a/node/runtime/pangolin/src/pallets/evm.rs
+++ b/node/runtime/pangolin/src/pallets/evm.rs
@@ -102,7 +102,7 @@ where
 	}
 
 	pub fn used_addresses() -> sp_std::vec::Vec<H160> {
-		sp_std::vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 1024, 1025, 21, 23, 24]
+		sp_std::vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 21, 23, 24, 1024, 1025]
 			.into_iter()
 			.map(|x| addr(x))
 			.collect()
@@ -113,10 +113,10 @@ impl<R> PrecompileSet for PangolinPrecompiles<R>
 where
 	Dispatch<R>: Precompile,
 	EthereumBridge<R>: Precompile,
+	R: darwinia_ethereum::Config,
 	StateStorage<R, StorageFilter>: Precompile,
 	Sub2SubBridge<R, ToPangoroMessageSender, bm_pangoro::ToPangoroOutboundPayLoad>: Precompile,
 	Transfer<R>: Precompile,
-	R: darwinia_ethereum::Config,
 {
 	fn execute(
 		&self,
@@ -150,11 +150,6 @@ where
 			// TODO: Change the transfer precompile address after https://github.com/darwinia-network/darwinia-common/issues/1259
 			a if a == addr(21) =>
 				Some(<Transfer<R>>::execute(input, target_gas, context, is_static)),
-			a if a == addr(1024) => Some(<StateStorage<R, StorageFilter>>::execute(
-				input, target_gas, context, is_static,
-			)),
-			a if a == addr(1025) =>
-				Some(<Dispatch<R>>::execute(input, target_gas, context, is_static)),
 			// TODO: Delete EthereumBridge and Sub2SubBridge precompiles in the futures.
 			a if a == addr(23) =>
 				Some(<EthereumBridge<R>>::execute(input, target_gas, context, is_static)),
@@ -163,10 +158,11 @@ where
 				ToPangoroMessageSender,
 				bm_pangoro::ToPangoroOutboundPayLoad,
 			>>::execute(input, target_gas, context, is_static)),
-			// Darwinia precompiles: 2048+ for experimental precompiles.
-			a if a == addr(2048) =>
-				Some(<BLS12381<R>>::execute(input, target_gas, context, is_static)),
-			a if a == addr(2049) => Some(<MPT<R>>::execute(input, target_gas, context, is_static)),
+			a if a == addr(1024) => Some(<StateStorage<R, StorageFilter>>::execute(
+				input, target_gas, context, is_static,
+			)),
+			a if a == addr(1025) =>
+				Some(<Dispatch<R>>::execute(input, target_gas, context, is_static)),
 			_ => None,
 		}
 	}

--- a/node/runtime/pangolin/src/pallets/evm.rs
+++ b/node/runtime/pangolin/src/pallets/evm.rs
@@ -102,7 +102,7 @@ where
 	}
 
 	pub fn used_addresses() -> sp_std::vec::Vec<H160> {
-		sp_std::vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 21, 23, 24, 1024, 1025]
+		sp_std::vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 21, 23, 24, 25, 1024, 1025]
 			.into_iter()
 			.map(|x| addr(x))
 			.collect()
@@ -147,7 +147,7 @@ where
 			a if a == addr(8) => Some(Bn128Pairing::execute(input, target_gas, context, is_static)),
 			a if a == addr(9) => Some(Blake2F::execute(input, target_gas, context, is_static)),
 			// Darwinia precompiles: 1024+ for stable precompiles.
-			// TODO: Change the transfer precompile address after https://github.com/darwinia-network/darwinia-common/issues/1259
+			// FIXME: Change the transfer precompile address after https://github.com/darwinia-network/darwinia-common/issues/1259
 			a if a == addr(21) =>
 				Some(<Transfer<R>>::execute(input, target_gas, context, is_static)),
 			// TODO: Delete EthereumBridge and Sub2SubBridge precompiles in the futures.
@@ -158,6 +158,11 @@ where
 				ToPangoroMessageSender,
 				bm_pangoro::ToPangoroOutboundPayLoad,
 			>>::execute(input, target_gas, context, is_static)),
+			// There are two StateStorage precompile instance now, the 25-StateStorage reserved to
+			// keep the compatibility, which will be removed in the future.
+			a if a == addr(25) => Some(<StateStorage<R, StorageFilter>>::execute(
+				input, target_gas, context, is_static,
+			)),
 			a if a == addr(1024) => Some(<StateStorage<R, StorageFilter>>::execute(
 				input, target_gas, context, is_static,
 			)),

--- a/node/runtime/pangoro/Cargo.toml
+++ b/node/runtime/pangoro/Cargo.toml
@@ -25,6 +25,7 @@ darwinia-bridge-bsc                   = { default-features = false, path = "../.
 darwinia-ethereum                     = { default-features = false, path = "../../../frame/dvm/ethereum" }
 darwinia-evm                          = { default-features = false, path = "../../../frame/dvm/evm" }
 darwinia-evm-precompile-bls12-381     = { default-features = false, path = "../../../frame/dvm/evm/precompiles/bls12381" }
+darwinia-evm-precompile-dispatch      = { default-features = false, path = "../../../frame/dvm/evm/precompiles/dispatch" }
 darwinia-evm-precompile-mpt           = { default-features = false, path = "../../../frame/dvm/evm/precompiles/mpt" }
 darwinia-evm-precompile-state-storage = { default-features = false, path = "../../../frame/dvm/evm/precompiles/state-storage" }
 darwinia-evm-precompile-transfer      = { default-features = false, path = "../../../frame/dvm/evm/precompiles/transfer" }
@@ -125,6 +126,7 @@ std = [
 	"darwinia-ethereum/std",
 	"darwinia-evm/std",
 	"darwinia-evm-precompile-bls12-381/std",
+	"darwinia-evm-precompile-dispatch/std",
 	"darwinia-evm-precompile-mpt/std",
 	"darwinia-evm-precompile-state-storage/std",
 	"darwinia-evm-precompile-transfer/std",

--- a/node/runtime/pangoro/src/pallets/evm.rs
+++ b/node/runtime/pangoro/src/pallets/evm.rs
@@ -21,6 +21,7 @@ use darwinia_evm::{
 	runner::stack::Runner, Config, EVMCurrencyAdapter, EnsureAddressTruncated, GasWeightMapping,
 };
 use darwinia_evm_precompile_bls12_381::BLS12381;
+use darwinia_evm_precompile_dispatch::Dispatch;
 use darwinia_evm_precompile_mpt::MPT;
 use darwinia_evm_precompile_state_storage::{StateStorage, StorageFilterT};
 use darwinia_evm_precompile_transfer::Transfer;
@@ -57,7 +58,7 @@ where
 	}
 
 	pub fn used_addresses() -> sp_std::vec::Vec<H160> {
-		sp_std::vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 21, 26, 27, 2048, 2049]
+		sp_std::vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 21, 1024, 1025, 2048, 2049]
 			.into_iter()
 			.map(|x| addr(x))
 			.collect()
@@ -67,10 +68,11 @@ where
 impl<R> PrecompileSet for PangoroPrecompiles<R>
 where
 	BLS12381<R>: Precompile,
+	Dispatch<R>: Precompile,
 	MPT<R>: Precompile,
+	R: darwinia_ethereum::Config,
 	StateStorage<R, StorageFilter>: Precompile,
 	Transfer<R>: Precompile,
-	R: darwinia_ethereum::Config,
 {
 	fn execute(
 		&self,

--- a/node/runtime/pangoro/src/pallets/evm.rs
+++ b/node/runtime/pangoro/src/pallets/evm.rs
@@ -100,13 +100,16 @@ where
 			a if a == addr(7) => Some(Bn128Mul::execute(input, target_gas, context, is_static)),
 			a if a == addr(8) => Some(Bn128Pairing::execute(input, target_gas, context, is_static)),
 			a if a == addr(9) => Some(Blake2F::execute(input, target_gas, context, is_static)),
-			// Darwinia precompiles: 1024+ for stable precompiles, 2048+ for experimental
-			// precompiles
+			// Darwinia precompiles: 1024+ for stable precompiles.
+			// TODO: Change the transfer precompile address after https://github.com/darwinia-network/darwinia-common/issues/1259
 			a if a == addr(21) =>
 				Some(<Transfer<R>>::execute(input, target_gas, context, is_static)),
-			a if a == addr(27) => Some(<StateStorage<R, StorageFilter>>::execute(
+			a if a == addr(1024) => Some(<StateStorage<R, StorageFilter>>::execute(
 				input, target_gas, context, is_static,
 			)),
+			a if a == addr(1025) =>
+				Some(<Dispatch<R>>::execute(input, target_gas, context, is_static)),
+			// Darwinia precompiles: 2048+ for experimental precompiles.
 			a if a == addr(2048) =>
 				Some(<BLS12381<R>>::execute(input, target_gas, context, is_static)),
 			a if a == addr(2049) => Some(<MPT<R>>::execute(input, target_gas, context, is_static)),


### PR DESCRIPTION
See https://github.com/darwinia-network/darwinia/issues/901 and https://github.com/darwinia-network/darwinia/issues/906

1. Install dispatch precompile to the Pangoro network runtime.
2. Update `StateStorage` address to `1024`, `Dispatch` precompile address to `1025`. Leave others untouched and add some comments.