### PR TITLE
Remove `DustCollector`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1862,7 +1862,6 @@ dependencies = [
  "ethereum-primitives",
  "frame-support",
  "frame-system",
- "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
  "sha3 0.9.1",

--- a/frame/balances/Cargo.toml
+++ b/frame/balances/Cargo.toml
@@ -13,8 +13,6 @@ version     = "2.8.13"
 # crates.io
 codec      = { package = "parity-scale-codec", version = "2.3", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
-# darwinia-network
-darwinia-support = { default-features = false, path = "../support" }
 # paritytech
 frame-support = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.3" }
 frame-system  = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.3" }
@@ -36,8 +34,6 @@ std = [
 	# crates.io
 	"codec/std",
 	"scale-info/std",
-	# darwinia-network
-	"darwinia-support/std",
 	# paritytech
 	"frame-support/std",
 	"frame-system/std",

--- a/frame/balances/src/tests_local.rs
+++ b/frame/balances/src/tests_local.rs
@@ -108,7 +108,6 @@ impl Config<RingInstance> for Test {
 	type ExistentialDeposit = ExistentialDeposit;
 	type MaxLocks = ();
 	type MaxReserves = MaxReserves;
-	type OtherCurrencies = (Kton,);
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }
@@ -126,7 +125,6 @@ impl Config<KtonInstance> for Test {
 	type ExistentialDeposit = ExistentialDeposit;
 	type MaxLocks = ();
 	type MaxReserves = MaxReserves;
-	type OtherCurrencies = (Ring,);
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }
@@ -228,65 +226,6 @@ fn emit_events_with_no_existential_deposit_suicide_with_dust() {
 				Event::System(frame_system::Event::KilledAccount(1)),
 				Event::Ring(crate::Event::DustLost(1, 1)),
 				Event::Ring(crate::Event::Slashed(1, 1)),
-			]
-		);
-	});
-}
-
-#[test]
-fn dust_collector_should_work() {
-	<ExtBuilder>::default().existential_deposit(100).build().execute_with(|| {
-		assert_ok!(Ring::set_balance(RawOrigin::Root.into(), 1, 100, 0));
-
-		assert_eq!(
-			events(),
-			[
-				Event::System(frame_system::Event::NewAccount(1)),
-				Event::Ring(crate::Event::Endowed(1, 100)),
-				Event::Ring(crate::Event::BalanceSet(1, 100, 0)),
-			]
-		);
-
-		let _ = Ring::slash(&1, 1);
-
-		assert_eq!(
-			events(),
-			[
-				Event::System(frame_system::Event::KilledAccount(1)),
-				Event::Ring(crate::Event::DustLost(1, 99)),
-				Event::Ring(crate::Event::Slashed(1, 1)),
-			]
-		);
-
-		// ---
-
-		assert_ok!(Ring::set_balance(RawOrigin::Root.into(), 1, 100, 0));
-		assert_ok!(Kton::set_balance(RawOrigin::Root.into(), 1, 100, 0));
-
-		assert_eq!(
-			events(),
-			[
-				Event::System(frame_system::Event::NewAccount(1)),
-				Event::Ring(crate::Event::Endowed(1, 100)),
-				Event::Ring(crate::Event::BalanceSet(1, 100, 0)),
-				Event::Kton(crate::Event::Endowed(1, 100)),
-				Event::Kton(crate::Event::BalanceSet(1, 100, 0)),
-			]
-		);
-
-		let _ = Ring::slash(&1, 1);
-
-		assert_eq!(events(), [Event::Ring(crate::Event::Slashed(1, 1))]);
-
-		let _ = Kton::slash(&1, 1);
-
-		assert_eq!(
-			events(),
-			[
-				Event::System(frame_system::Event::KilledAccount(1)),
-				Event::Ring(crate::Event::DustLost(1, 99)),
-				Event::Kton(crate::Event::DustLost(1, 99)),
-				Event::Kton(crate::Event::Slashed(1, 1))
 			]
 		);
 	});

--- a/frame/balances/src/tests_reentrancy.rs
+++ b/frame/balances/src/tests_reentrancy.rs
@@ -111,7 +111,6 @@ impl Config<RingInstance> for Test {
 	type ExistentialDeposit = ExistentialDeposit;
 	type MaxLocks = MaxLocks;
 	type MaxReserves = MaxReserves;
-	type OtherCurrencies = ();
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }

--- a/frame/bridge/ethereum/src/mock.rs
+++ b/frame/bridge/ethereum/src/mock.rs
@@ -72,7 +72,6 @@ impl darwinia_balances::Config<RingInstance> for Test {
 	type ExistentialDeposit = ();
 	type MaxLocks = ();
 	type MaxReserves = ();
-	type OtherCurrencies = ();
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }

--- a/frame/bridge/relay-authorities/src/mock.rs
+++ b/frame/bridge/relay-authorities/src/mock.rs
@@ -88,7 +88,6 @@ impl darwinia_balances::Config<RingInstance> for Test {
 	type ExistentialDeposit = ();
 	type MaxLocks = ();
 	type MaxReserves = ();
-	type OtherCurrencies = ();
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }

--- a/frame/bridge/relayer-game/src/mock.rs
+++ b/frame/bridge/relayer-game/src/mock.rs
@@ -289,7 +289,6 @@ impl darwinia_balances::Config<RingInstance> for Test {
 	type ExistentialDeposit = ExistentialDeposit;
 	type MaxLocks = ();
 	type MaxReserves = ();
-	type OtherCurrencies = ();
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }

--- a/frame/dvm/ethereum/src/mock.rs
+++ b/frame/dvm/ethereum/src/mock.rs
@@ -106,7 +106,6 @@ impl darwinia_balances::Config<RingInstance> for Test {
 	type ExistentialDeposit = ExistentialDeposit;
 	type MaxLocks = MaxLocks;
 	type MaxReserves = ();
-	type OtherCurrencies = ();
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }
@@ -119,7 +118,6 @@ impl darwinia_balances::Config<KtonInstance> for Test {
 	type ExistentialDeposit = ExistentialDeposit;
 	type MaxLocks = MaxLocks;
 	type MaxReserves = ();
-	type OtherCurrencies = ();
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }
@@ -363,12 +361,18 @@ impl CallValidate<AccountId32, Origin, Call> for CallValidator {
 								<Test as darwinia_evm::Config>::FeeCalculator::min_gas_price();
 							let fee = t.gas_limit.saturating_mul(gas_price);
 
-							// MaxUsableBalanceFromRelayer is the cap limitation for fee in case gas_limit is too large for relayer
-							if fee > decimal_convert(MaxUsableBalanceFromRelayer::get().into(), None) {
-								return Err(TransactionValidityError::Invalid(InvalidTransaction::Custom(2u8)));
+							// MaxUsableBalanceFromRelayer is the cap limitation for fee in case
+							// gas_limit is too large for relayer
+							if fee
+								> decimal_convert(MaxUsableBalanceFromRelayer::get().into(), None)
+							{
+								return Err(TransactionValidityError::Invalid(
+									InvalidTransaction::Custom(2u8),
+								));
 							}
 
-							// Already done `evm_ensure_can_withdraw` in check_receiving_before_dispatch
+							// Already done `evm_ensure_can_withdraw` in
+							// check_receiving_before_dispatch
 							let derived_substrate_address =
 								<Test as darwinia_evm::Config>::IntoAccountId::derive_substrate_address(*id);
 
@@ -379,7 +383,9 @@ impl CallValidate<AccountId32, Origin, Call> for CallValidator {
 							);
 
 							if result.is_err() {
-								return Err(TransactionValidityError::Invalid(InvalidTransaction::Custom(3u8)));
+								return Err(TransactionValidityError::Invalid(
+									InvalidTransaction::Custom(3u8),
+								));
 							}
 
 							Ok(())

--- a/frame/dvm/evm/precompiles/state-storage/src/tests.rs
+++ b/frame/dvm/evm/precompiles/state-storage/src/tests.rs
@@ -110,7 +110,6 @@ impl darwinia_balances::Config<RingInstance> for Test {
 	type ExistentialDeposit = ExistentialDeposit;
 	type MaxLocks = MaxLocks;
 	type MaxReserves = ();
-	type OtherCurrencies = ();
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }
@@ -123,7 +122,6 @@ impl darwinia_balances::Config<KtonInstance> for Test {
 	type ExistentialDeposit = ExistentialDeposit;
 	type MaxLocks = MaxLocks;
 	type MaxReserves = ();
-	type OtherCurrencies = ();
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }

--- a/frame/dvm/evm/precompiles/transfer/src/tests/mock.rs
+++ b/frame/dvm/evm/precompiles/transfer/src/tests/mock.rs
@@ -105,7 +105,6 @@ impl darwinia_balances::Config<RingInstance> for Test {
 	type ExistentialDeposit = ExistentialDeposit;
 	type MaxLocks = MaxLocks;
 	type MaxReserves = ();
-	type OtherCurrencies = ();
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }
@@ -118,7 +117,6 @@ impl darwinia_balances::Config<KtonInstance> for Test {
 	type ExistentialDeposit = ExistentialDeposit;
 	type MaxLocks = MaxLocks;
 	type MaxReserves = ();
-	type OtherCurrencies = ();
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }

--- a/frame/dvm/evm/src/tests.rs
+++ b/frame/dvm/evm/src/tests.rs
@@ -83,7 +83,6 @@ impl darwinia_balances::Config<RingInstance> for Test {
 	type ExistentialDeposit = ExistentialDeposit;
 	type MaxLocks = ();
 	type MaxReserves = ();
-	type OtherCurrencies = ();
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }
@@ -96,7 +95,6 @@ impl darwinia_balances::Config<KtonInstance> for Test {
 	type ExistentialDeposit = ExistentialDeposit;
 	type MaxLocks = ();
 	type MaxReserves = ();
-	type OtherCurrencies = ();
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -204,7 +204,6 @@ impl darwinia_balances::Config<RingInstance> for Test {
 	type ExistentialDeposit = ExistentialDeposit;
 	type MaxLocks = MaxLocks;
 	type MaxReserves = ();
-	type OtherCurrencies = ();
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }
@@ -217,7 +216,6 @@ impl darwinia_balances::Config<KtonInstance> for Test {
 	type ExistentialDeposit = ExistentialDeposit;
 	type MaxLocks = MaxLocks;
 	type MaxReserves = ();
-	type OtherCurrencies = ();
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }

--- a/frame/support/Cargo.toml
+++ b/frame/support/Cargo.toml
@@ -13,7 +13,6 @@ version     = "2.8.13"
 # crates.io
 codec                 = { package = "parity-scale-codec", version = "2.3", default-features = false, features = ["derive"] }
 ethereum              = { version = "0.11.1", default-features = false, features = ["with-codec"] }
-impl-trait-for-tuples = { version = "0.2" }
 scale-info            = { version = "1.0", default-features = false, features = ["derive"] }
 sha3                  = { version = "0.9", default-features = false }
 # darwinia-network

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -26,10 +26,7 @@ pub mod testing;
 pub mod traits;
 
 pub mod balance {
-	pub use crate::{
-		structs::{StakingLock, Unbonding},
-		traits::DustCollector,
-	};
+	pub use crate::structs::{StakingLock, Unbonding};
 }
 use sp_std::{vec, vec::Vec};
 

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -20,35 +20,12 @@
 use core::fmt::Debug;
 // --- crates.io ---
 use codec::FullCodec;
-use impl_trait_for_tuples::impl_for_tuples;
 use scale_info::TypeInfo;
 // --- paritytech ---
 use sp_runtime::{DispatchError, DispatchResult};
 use sp_std::prelude::*;
 // --- darwinia-network ---
 use ethereum_primitives::receipt::EthereumTransactionIndex;
-
-pub trait DustCollector<AccountId> {
-	fn is_dust(who: &AccountId) -> bool;
-
-	fn collect(who: &AccountId);
-}
-#[impl_for_tuples(30)]
-impl<AccountId> DustCollector<AccountId> for Currencies {
-	fn is_dust(who: &AccountId) -> bool {
-		for_tuples!( #(
-			if !Currencies::is_dust(who) {
-				return false;
-			}
-		)* );
-
-		true
-	}
-
-	fn collect(who: &AccountId) {
-		for_tuples!( #( Currencies::collect(who); )* );
-	}
-}
 
 /// Callback on ethereum-backing module
 pub trait OnDepositRedeem<AccountId, Balance> {

--- a/frame/transaction-pause/src/mock.rs
+++ b/frame/transaction-pause/src/mock.rs
@@ -81,7 +81,6 @@ impl darwinia_balances::Config<RingInstance> for Test {
 	type ExistentialDeposit = NativeTokenExistentialDeposit;
 	type MaxLocks = ();
 	type MaxReserves = ();
-	type OtherCurrencies = ();
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }

--- a/frame/wormhole/backing/ethereum/src/mock.rs
+++ b/frame/wormhole/backing/ethereum/src/mock.rs
@@ -133,7 +133,6 @@ impl darwinia_balances::Config<KtonInstance> for Test {
 	type ExistentialDeposit = ();
 	type MaxLocks = ();
 	type MaxReserves = ();
-	type OtherCurrencies = ();
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }
@@ -146,7 +145,6 @@ impl darwinia_balances::Config<RingInstance> for Test {
 	type ExistentialDeposit = ();
 	type MaxLocks = ();
 	type MaxReserves = ();
-	type OtherCurrencies = ();
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }

--- a/frame/wormhole/backing/s2s/src/tests.rs
+++ b/frame/wormhole/backing/s2s/src/tests.rs
@@ -60,7 +60,6 @@ impl darwinia_balances::Config<RingInstance> for Test {
 	type ExistentialDeposit = ExistentialDeposit;
 	type MaxLocks = ();
 	type MaxReserves = ();
-	type OtherCurrencies = ();
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }

--- a/frame/wormhole/issuing/s2s/src/mock.rs
+++ b/frame/wormhole/issuing/s2s/src/mock.rs
@@ -78,7 +78,6 @@ impl darwinia_balances::Config<RingInstance> for Test {
 	type ExistentialDeposit = ExistentialDeposit;
 	type MaxLocks = ();
 	type MaxReserves = ();
-	type OtherCurrencies = ();
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }
@@ -91,7 +90,6 @@ impl darwinia_balances::Config<KtonInstance> for Test {
 	type ExistentialDeposit = ExistentialDeposit;
 	type MaxLocks = ();
 	type MaxReserves = ();
-	type OtherCurrencies = ();
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }

--- a/node/runtime/pangolin/src/pallets/balances.rs
+++ b/node/runtime/pangolin/src/pallets/balances.rs
@@ -20,7 +20,6 @@ impl Config<RingInstance> for Runtime {
 	type ExistentialDeposit = ExistentialDeposit;
 	type MaxLocks = MaxLocks;
 	type MaxReserves = MaxReserves;
-	type OtherCurrencies = (Kton,);
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }
@@ -33,7 +32,6 @@ impl Config<KtonInstance> for Runtime {
 	type ExistentialDeposit = ExistentialDeposit;
 	type MaxLocks = MaxLocks;
 	type MaxReserves = MaxReserves;
-	type OtherCurrencies = (Ring,);
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }

--- a/node/runtime/pangoro/src/pallets/balances.rs
+++ b/node/runtime/pangoro/src/pallets/balances.rs
@@ -20,7 +20,6 @@ impl Config<RingInstance> for Runtime {
 	type ExistentialDeposit = ExistentialDeposit;
 	type MaxLocks = MaxLocks;
 	type MaxReserves = MaxReserves;
-	type OtherCurrencies = (Kton,);
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }
@@ -33,7 +32,6 @@ impl Config<KtonInstance> for Runtime {
 	type ExistentialDeposit = ExistentialDeposit;
 	type MaxLocks = MaxLocks;
 	type MaxReserves = MaxReserves;
-	type OtherCurrencies = (Ring,);
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }

--- a/node/runtime/template/src/pallets/balances.rs
+++ b/node/runtime/template/src/pallets/balances.rs
@@ -20,7 +20,6 @@ impl Config<RingInstance> for Runtime {
 	type ExistentialDeposit = ExistentialDeposit;
 	type MaxLocks = MaxLocks;
 	type MaxReserves = MaxReserves;
-	type OtherCurrencies = (Kton,);
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }
@@ -33,7 +32,6 @@ impl Config<KtonInstance> for Runtime {
 	type ExistentialDeposit = ExistentialDeposit;
 	type MaxLocks = MaxLocks;
 	type MaxReserves = MaxReserves;
-	type OtherCurrencies = (Ring,);
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = ();
 }


### PR DESCRIPTION
Due to the EVM, ED must be set to 0.
So, this checker is useless now.

Close https://github.com/darwinia-network/darwinia/issues/653.

Part of #1157.
Part of #831.