### PR TITLE
Use `NextAuthorities` Instead

### DIFF
--- a/frame/bridge/ecdsa-authority/Cargo.toml
+++ b/frame/bridge/ecdsa-authority/Cargo.toml
@@ -11,7 +11,7 @@ version     = "2.8.17"
 
 [dependencies]
 # crates.io
-codec      = { package = "parity-scale-codec", version = "2.3", default-features = false }
+codec      = { package = "parity-scale-codec", version = "2.3", default-features = false, features = ["derive"] }
 ethabi     = { version = "15.0", default-features = false }
 scale-info = { version = "1.0", default-features = false }
 # paritytech

--- a/frame/bridge/ecdsa-authority/src/lib.rs
+++ b/frame/bridge/ecdsa-authority/src/lib.rs
@@ -142,7 +142,7 @@ pub mod pallet {
 	#[pallet::getter(fn authorities_change_to_sign)]
 	pub type AuthoritiesChangeToSign<T: Config> = StorageValue<
 		_,
-		((Operation, Message), BoundedVec<(Address, Signature), T::MaxAuthorities>),
+		(Operation, Message, BoundedVec<(Address, Signature), T::MaxAuthorities>),
 		OptionQuery,
 	>;
 
@@ -306,7 +306,7 @@ pub mod pallet {
 			let authorities = Self::ensure_authority(&address)?;
 			let mut authorities_change_to_sign =
 				<AuthoritiesChangeToSign<T>>::get().ok_or(<Error<T>>::NoAuthoritiesChange)?;
-			let ((_, message), collected) = &mut authorities_change_to_sign;
+			let (_, message, collected) = &mut authorities_change_to_sign;
 
 			Self::ensure_not_submitted(&address, &collected)?;
 
@@ -320,7 +320,7 @@ pub mod pallet {
 			if Self::check_threshold(collected.len() as _, authorities.len() as _) {
 				Self::apply_next_authorities();
 
-				let ((operation, message), collected) = authorities_change_to_sign;
+				let (operation, message, collected) = authorities_change_to_sign;
 
 				Self::deposit_event(<Event<T>>::CollectedEnoughAuthoritiesChangeSignatures((
 					operation,
@@ -432,7 +432,7 @@ pub mod pallet {
 				]),
 			);
 
-			<AuthoritiesChangeToSign<T>>::put(((operation, message), BoundedVec::default()));
+			<AuthoritiesChangeToSign<T>>::put((operation, message, BoundedVec::default()));
 
 			Self::deposit_event(<Event<T>>::CollectingAuthoritiesChangeSignatures(message));
 		}

--- a/frame/bridge/ecdsa-authority/src/lib.rs
+++ b/frame/bridge/ecdsa-authority/src/lib.rs
@@ -295,7 +295,7 @@ pub mod pallet {
 			// Take the value here.
 			// If collected enough signatures, leave the empty `AuthoritiesChangeToSign` in storage.
 			let mut authorities_change_to_sign =
-				<AuthoritiesChangeToSign<T>>::take().ok_or(<Error<T>>::NoAuthoritiesChange)?;
+				<AuthoritiesChangeToSign<T>>::get().ok_or(<Error<T>>::NoAuthoritiesChange)?;
 			let ((_, message), collected) = &mut authorities_change_to_sign;
 
 			Self::ensure_not_submitted(&address, &collected)?;
@@ -317,6 +317,9 @@ pub mod pallet {
 					message,
 					collected.to_vec(),
 				)));
+				Self::apply_next_authorities(
+
+				);
 			} else {
 				<AuthoritiesChangeToSign<T>>::put(authorities_change_to_sign);
 			}
@@ -429,6 +432,12 @@ pub mod pallet {
 			<AuthoritiesChangeToSign<T>>::put(((operation, message), BoundedVec::default()));
 
 			Self::deposit_event(<Event<T>>::CollectingAuthoritiesChangeSignatures(message));
+		}
+
+		pub (crate) fn apply_next_authorities() {
+			<AuthoritiesChangeToSign<T>>::kill();
+			<Authorities<T>>::put(<NextAuthorities<T>>::get());
+			<Nonce<T>>::mutate(|nonce| *nonce += 1);
 		}
 
 		fn try_update_message_root(at: T::BlockNumber) -> Option<Hash> {

--- a/frame/bridge/ecdsa-authority/src/mock.rs
+++ b/frame/bridge/ecdsa-authority/src/mock.rs
@@ -153,8 +153,10 @@ pub(crate) fn sign(secret_key: &SecretKey, message: &Message) -> Signature {
 	Signature(signature)
 }
 
-pub(crate) fn clear_authorities_change() {
+pub(crate) fn presume_authority_change_succeed() {
 	<AuthoritiesChangeToSign<Test>>::kill();
+	<Authorities<Test>>::put(<NextAuthorities<Test>>::get());
+	<Nonce<Test>>::mutate(|nonce| *nonce += 1);
 }
 
 pub(crate) fn new_message_root(byte: u8) {

--- a/frame/bridge/ecdsa-authority/src/mock.rs
+++ b/frame/bridge/ecdsa-authority/src/mock.rs
@@ -154,9 +154,7 @@ pub(crate) fn sign(secret_key: &SecretKey, message: &Message) -> Signature {
 }
 
 pub(crate) fn presume_authority_change_succeed() {
-	<AuthoritiesChangeToSign<Test>>::kill();
-	<Authorities<Test>>::put(<NextAuthorities<Test>>::get());
-	<Nonce<Test>>::mutate(|nonce| *nonce += 1);
+	EcdsaAuthority::apply_next_authorities();
 }
 
 pub(crate) fn new_message_root(byte: u8) {

--- a/frame/bridge/ecdsa-authority/src/primitives.rs
+++ b/frame/bridge/ecdsa-authority/src/primitives.rs
@@ -1,8 +1,12 @@
 pub(crate) use sp_core::ecdsa::Signature;
 
+// --- crates.io ---
+use codec::{Decode, Encode};
+use scale_info::TypeInfo;
 // --- paritytech ---
 use sp_core::{H160, H256};
 use sp_io::{crypto, hashing};
+use sp_runtime::RuntimeDebug;
 
 pub(crate) type Address = H160;
 pub(crate) type Hash = H256;
@@ -55,23 +59,24 @@ impl Sign {
 	}
 }
 
-pub(crate) enum Method {
+#[derive(Clone, PartialEq, Encode, Decode, RuntimeDebug, TypeInfo)]
+pub enum Operation {
 	AddMember { new: Address },
 	RemoveMember { pre: Address, old: Address },
 	SwapMembers { pre: Address, old: Address, new: Address },
 }
-impl Method {
+impl Operation {
 	pub(crate) fn id(&self) -> [u8; 4] {
 		match self {
 			// bytes4(keccak256("add_relayer(address,uint256)"))
 			// 0xb7aafe32
-			Method::AddMember { .. } => [183, 170, 254, 50],
+			Self::AddMember { .. } => [183, 170, 254, 50],
 			// bytes4(keccak256("remove_relayer(address,address,uint256)"))
 			// 0x8621d1fa
-			Method::RemoveMember { .. } => [134, 33, 209, 250],
+			Self::RemoveMember { .. } => [134, 33, 209, 250],
 			// bytes4(keccak256("swap_relayer(address,address,address)"))
 			// 0xcb76085b
-			Method::SwapMembers { .. } => [203, 118, 8, 91],
+			Self::SwapMembers { .. } => [203, 118, 8, 91],
 		}
 	}
 }

--- a/frame/bridge/ecdsa-authority/src/tests.rs
+++ b/frame/bridge/ecdsa-authority/src/tests.rs
@@ -448,3 +448,10 @@ fn tx_fee() {
 		);
 	});
 }
+
+#[test]
+fn on_runtime_upgrade() {
+	ExtBuilder::default().build().execute_with(|| {
+		assert_eq!(EcdsaAuthority::test_on_runtime_upgrade(), b"EcdsaAuthority");
+	});
+}

--- a/frame/bridge/ecdsa-authority/src/tests.rs
+++ b/frame/bridge/ecdsa-authority/src/tests.rs
@@ -283,7 +283,9 @@ fn submit_authorities_change_signature() {
 			EcdsaAuthorityError::BadSignature
 		);
 
+		let nonce = EcdsaAuthority::nonce();
 		let signature_1 = sign(&secret_key_1, &message);
+		assert_eq!(EcdsaAuthority::nonce(), nonce);
 		assert_ok!(EcdsaAuthority::submit_authorities_change_signature(
 			Origin::signed(Default::default()),
 			address_1,
@@ -291,7 +293,10 @@ fn submit_authorities_change_signature() {
 		));
 		assert_eq!(
 			EcdsaAuthority::authorities_change_to_sign(),
-			Some(((operation.clone(), message), BoundedVec::try_from(vec![(address_1, signature_1.clone())]).unwrap()))
+			Some((
+				(operation.clone(), message),
+				BoundedVec::try_from(vec![(address_1, signature_1.clone())]).unwrap()
+			))
 		);
 
 		let signature_2 = sign(&secret_key_2, &message);
@@ -300,11 +305,13 @@ fn submit_authorities_change_signature() {
 			address_2,
 			signature_2.clone(),
 		));
+		assert_eq!(EcdsaAuthority::nonce(), nonce + 1);
 		assert!(EcdsaAuthority::authorities_change_to_sign().is_none());
 		assert_eq!(
 			ecdsa_authority_events(),
 			vec![Event::CollectedEnoughAuthoritiesChangeSignatures((
-				operation, message,
+				operation,
+				message,
 				vec![(address_1, signature_1), (address_2, signature_2)]
 			))]
 		);
@@ -360,7 +367,9 @@ fn submit_new_message_root_signature() {
 			EcdsaAuthorityError::NotAuthority
 		);
 
+		let nonce = EcdsaAuthority::nonce();
 		let signature_1 = sign(&secret_key_1, &message);
+		assert_eq!(EcdsaAuthority::nonce(), nonce);
 		assert_ok!(EcdsaAuthority::submit_new_message_root_signature(
 			Origin::signed(Default::default()),
 			address_1,
@@ -377,6 +386,7 @@ fn submit_new_message_root_signature() {
 			address_2,
 			signature_2.clone(),
 		));
+		assert_eq!(EcdsaAuthority::nonce(), nonce);
 		assert!(EcdsaAuthority::new_message_root_to_sign().is_none());
 		assert_eq!(
 			ecdsa_authority_events(),

--- a/frame/bridge/ecdsa-authority/src/tests.rs
+++ b/frame/bridge/ecdsa-authority/src/tests.rs
@@ -34,6 +34,7 @@ fn add_authority() {
 			EcdsaAuthorityError::OnAuthoritiesChange
 		);
 		presume_authority_change_succeed();
+		assert_eq!(EcdsaAuthority::authorities(), vec![address]);
 		assert_eq!(EcdsaAuthority::nonce(), 1);
 
 		// Case 2.
@@ -108,6 +109,7 @@ fn remove_authority() {
 			EcdsaAuthorityError::OnAuthoritiesChange
 		);
 		presume_authority_change_succeed();
+		assert_eq!(EcdsaAuthority::authorities(), vec![address_2]);
 		assert_eq!(EcdsaAuthority::nonce(), 1);
 
 		// Case 2.
@@ -172,6 +174,7 @@ fn swap_authority() {
 			EcdsaAuthorityError::OnAuthoritiesChange
 		);
 		presume_authority_change_succeed();
+		assert_eq!(EcdsaAuthority::authorities(), vec![address_2]);
 		assert_eq!(EcdsaAuthority::nonce(), 1);
 
 		// Case 2.

--- a/frame/bridge/ecdsa-authority/src/tests.rs
+++ b/frame/bridge/ecdsa-authority/src/tests.rs
@@ -9,18 +9,19 @@ fn add_authority() {
 
 	ExtBuilder::default().build().execute_with(|| {
 		assert!(EcdsaAuthority::authorities().is_empty());
+		assert!(EcdsaAuthority::next_authorities().is_empty());
 		assert_eq!(EcdsaAuthority::nonce(), 0);
 		assert_ok!(EcdsaAuthority::add_authority(Origin::root(), address));
-		assert_eq!(EcdsaAuthority::authorities(), vec![address]);
-		assert_eq!(EcdsaAuthority::previous_authorities(), vec![]);
-		assert_eq!(EcdsaAuthority::nonce(), 1);
+		assert!(EcdsaAuthority::authorities().is_empty());
+		assert_eq!(EcdsaAuthority::next_authorities(), vec![address]);
+		assert_eq!(EcdsaAuthority::nonce(), 0);
 		let message = [
 			95, 104, 154, 117, 185, 44, 82, 85, 71, 213, 152, 243, 143, 82, 23, 37, 45, 55, 74,
 			243, 153, 158, 202, 214, 210, 40, 252, 113, 20, 63, 77, 71,
 		];
 		assert_eq!(
 			EcdsaAuthority::authorities_change_to_sign(),
-			Some((message, Default::default()))
+			Some(((Operation::AddMember { new: address }, message), Default::default()))
 		);
 		assert_eq!(
 			ecdsa_authority_events(),
@@ -32,7 +33,8 @@ fn add_authority() {
 			EcdsaAuthority::add_authority(Origin::root(), address),
 			EcdsaAuthorityError::OnAuthoritiesChange
 		);
-		clear_authorities_change();
+		presume_authority_change_succeed();
+		assert_eq!(EcdsaAuthority::nonce(), 1);
 
 		// Case 2.
 		assert_noop!(
@@ -49,8 +51,8 @@ fn add_authority() {
 		// Case 4.
 		(1..MaxAuthorities::get()).for_each(|i| {
 			assert_ok!(EcdsaAuthority::add_authority(Origin::root(), Address::repeat_byte(i as _)));
+			presume_authority_change_succeed();
 			assert_eq!(EcdsaAuthority::nonce(), 1 + i);
-			clear_authorities_change();
 		});
 		assert_noop!(
 			EcdsaAuthority::add_authority(
@@ -78,18 +80,22 @@ fn remove_authority() {
 
 	ExtBuilder::default().authorities(vec![address_1, address_2]).build().execute_with(|| {
 		assert_eq!(EcdsaAuthority::authorities(), vec![address_1, address_2]);
+		assert_eq!(EcdsaAuthority::next_authorities(), vec![address_1, address_2]);
 		assert_eq!(EcdsaAuthority::nonce(), 0);
 		assert_ok!(EcdsaAuthority::remove_authority(Origin::root(), address_1));
-		assert_eq!(EcdsaAuthority::authorities(), vec![address_2]);
-		assert_eq!(EcdsaAuthority::previous_authorities(), vec![address_1, address_2]);
-		assert_eq!(EcdsaAuthority::nonce(), 1);
+		assert_eq!(EcdsaAuthority::authorities(), vec![address_1, address_2]);
+		assert_eq!(EcdsaAuthority::next_authorities(), vec![address_2]);
+		assert_eq!(EcdsaAuthority::nonce(), 0);
 		let message = [
 			44, 25, 30, 94, 69, 250, 185, 115, 202, 60, 67, 106, 30, 177, 187, 35, 107, 25, 207,
 			57, 209, 20, 165, 40, 174, 157, 168, 124, 111, 62, 83, 176,
 		];
 		assert_eq!(
 			EcdsaAuthority::authorities_change_to_sign(),
-			Some((message, Default::default()))
+			Some((
+				(Operation::RemoveMember { pre: AUTHORITY_SENTINEL, old: address_1 }, message),
+				Default::default()
+			))
 		);
 		assert_eq!(
 			ecdsa_authority_events(),
@@ -101,7 +107,8 @@ fn remove_authority() {
 			EcdsaAuthority::add_authority(Origin::root(), address_1),
 			EcdsaAuthorityError::OnAuthoritiesChange
 		);
-		clear_authorities_change();
+		presume_authority_change_succeed();
+		assert_eq!(EcdsaAuthority::nonce(), 1);
 
 		// Case 2.
 		assert_noop!(
@@ -130,18 +137,29 @@ fn swap_authority() {
 
 	ExtBuilder::default().authorities(vec![address_1]).build().execute_with(|| {
 		assert_eq!(EcdsaAuthority::authorities(), vec![address_1]);
+		assert_eq!(EcdsaAuthority::next_authorities(), vec![address_1]);
 		assert_eq!(EcdsaAuthority::nonce(), 0);
 		assert_ok!(EcdsaAuthority::swap_authority(Origin::root(), address_1, address_2));
-		assert_eq!(EcdsaAuthority::authorities(), vec![address_2]);
-		assert_eq!(EcdsaAuthority::previous_authorities(), vec![address_1]);
-		assert_eq!(EcdsaAuthority::nonce(), 1);
+		assert_eq!(EcdsaAuthority::authorities(), vec![address_1]);
+		assert_eq!(EcdsaAuthority::next_authorities(), vec![address_2]);
+		assert_eq!(EcdsaAuthority::nonce(), 0);
 		let message = [
 			80, 165, 90, 130, 101, 89, 244, 106, 39, 22, 87, 235, 108, 75, 101, 52, 41, 12, 235, 9,
 			56, 188, 57, 212, 91, 99, 31, 109, 115, 68, 233, 183,
 		];
 		assert_eq!(
 			EcdsaAuthority::authorities_change_to_sign(),
-			Some((message, Default::default()))
+			Some((
+				(
+					Operation::SwapMembers {
+						pre: AUTHORITY_SENTINEL,
+						old: address_1,
+						new: address_2
+					},
+					message
+				),
+				Default::default()
+			))
 		);
 		assert_eq!(
 			ecdsa_authority_events(),
@@ -153,7 +171,8 @@ fn swap_authority() {
 			EcdsaAuthority::swap_authority(Origin::root(), address_2, address_1),
 			EcdsaAuthorityError::OnAuthoritiesChange
 		);
-		clear_authorities_change();
+		presume_authority_change_succeed();
+		assert_eq!(EcdsaAuthority::nonce(), 1);
 
 		// Case 2.
 		assert_noop!(
@@ -223,7 +242,7 @@ fn sync_interval_and_max_pending_period() {
 fn submit_authorities_change_signature() {
 	let (secret_key_1, address_1) = gen_pair(1);
 	let (secret_key_2, address_2) = gen_pair(2);
-	let (secret_key_3, address_3) = gen_pair(3);
+	let (_, address_3) = gen_pair(3);
 
 	ExtBuilder::default().authorities(vec![address_1, address_2]).build().execute_with(|| {
 		// Case 1.
@@ -237,13 +256,14 @@ fn submit_authorities_change_signature() {
 		);
 
 		assert_ok!(EcdsaAuthority::add_authority(Origin::root(), address_3));
+		let operation = Operation::AddMember { new: address_3 };
 		let message = [
 			207, 80, 241, 175, 3, 59, 89, 65, 13, 55, 249, 77, 110, 229, 85, 220, 109, 138, 196,
 			148, 202, 209, 242, 217, 244, 40, 240, 171, 115, 110, 17, 53,
 		];
 		assert_eq!(
 			EcdsaAuthority::authorities_change_to_sign(),
-			Some((message, Default::default()))
+			Some(((operation.clone(), message), Default::default()))
 		);
 		assert_eq!(
 			ecdsa_authority_events(),
@@ -260,17 +280,6 @@ fn submit_authorities_change_signature() {
 			EcdsaAuthorityError::BadSignature
 		);
 
-		// Case 3.
-		let signature_3 = sign(&secret_key_3, &message);
-		assert_noop!(
-			EcdsaAuthority::submit_authorities_change_signature(
-				Origin::signed(Default::default()),
-				address_3,
-				signature_3,
-			),
-			EcdsaAuthorityError::NotPreviousAuthority
-		);
-
 		let signature_1 = sign(&secret_key_1, &message);
 		assert_ok!(EcdsaAuthority::submit_authorities_change_signature(
 			Origin::signed(Default::default()),
@@ -279,7 +288,7 @@ fn submit_authorities_change_signature() {
 		));
 		assert_eq!(
 			EcdsaAuthority::authorities_change_to_sign(),
-			Some((message, BoundedVec::try_from(vec![(address_1, signature_1.clone())]).unwrap()))
+			Some(((operation.clone(), message), BoundedVec::try_from(vec![(address_1, signature_1.clone())]).unwrap()))
 		);
 
 		let signature_2 = sign(&secret_key_2, &message);
@@ -292,7 +301,7 @@ fn submit_authorities_change_signature() {
 		assert_eq!(
 			ecdsa_authority_events(),
 			vec![Event::CollectedEnoughAuthoritiesChangeSignatures((
-				message,
+				operation, message,
 				vec![(address_1, signature_1), (address_2, signature_2)]
 			))]
 		);

--- a/frame/bridge/ecdsa-authority/src/tests.rs
+++ b/frame/bridge/ecdsa-authority/src/tests.rs
@@ -21,7 +21,7 @@ fn add_authority() {
 		];
 		assert_eq!(
 			EcdsaAuthority::authorities_change_to_sign(),
-			Some(((Operation::AddMember { new: address }, message), Default::default()))
+			Some((Operation::AddMember { new: address }, message, Default::default()))
 		);
 		assert_eq!(
 			ecdsa_authority_events(),
@@ -94,7 +94,8 @@ fn remove_authority() {
 		assert_eq!(
 			EcdsaAuthority::authorities_change_to_sign(),
 			Some((
-				(Operation::RemoveMember { pre: AUTHORITY_SENTINEL, old: address_1 }, message),
+				Operation::RemoveMember { pre: AUTHORITY_SENTINEL, old: address_1 },
+				message,
 				Default::default()
 			))
 		);
@@ -152,14 +153,8 @@ fn swap_authority() {
 		assert_eq!(
 			EcdsaAuthority::authorities_change_to_sign(),
 			Some((
-				(
-					Operation::SwapMembers {
-						pre: AUTHORITY_SENTINEL,
-						old: address_1,
-						new: address_2
-					},
-					message
-				),
+				Operation::SwapMembers { pre: AUTHORITY_SENTINEL, old: address_1, new: address_2 },
+				message,
 				Default::default()
 			))
 		);
@@ -266,7 +261,7 @@ fn submit_authorities_change_signature() {
 		];
 		assert_eq!(
 			EcdsaAuthority::authorities_change_to_sign(),
-			Some(((operation.clone(), message), Default::default()))
+			Some((operation.clone(), message, Default::default()))
 		);
 		assert_eq!(
 			ecdsa_authority_events(),
@@ -294,7 +289,8 @@ fn submit_authorities_change_signature() {
 		assert_eq!(
 			EcdsaAuthority::authorities_change_to_sign(),
 			Some((
-				(operation.clone(), message),
+				operation.clone(),
+				message,
 				BoundedVec::try_from(vec![(address_1, signature_1.clone())]).unwrap()
 			))
 		);


### PR DESCRIPTION
Make things more friendly to bridger.
Bridger only needs to focus on `Authorities` storage while the authority set is changing.

cc @fewensa @hujw77 