### PR TITLE
Only keep the lane monitored by the bridgers

### DIFF
--- a/node/runtime/pangolin/src/bridges_message/pangolin_parachain.rs
+++ b/node/runtime/pangolin/src/bridges_message/pangolin_parachain.rs
@@ -140,7 +140,7 @@ impl ThisChainWithMessages for Pangolin {
 	type Call = Call;
 
 	fn is_outbound_lane_enabled(lane: &LaneId) -> bool {
-		*lane == [0, 0, 0, 0] || *lane == [0, 0, 0, 1] || *lane == PANGOLIN_PANGOLIN_PARACHAIN_LANE
+		*lane == PANGOLIN_PANGOLIN_PARACHAIN_LANE
 	}
 
 	fn maximal_pending_messages_at_outbound_lane() -> MessageNonce {

--- a/node/runtime/pangolin/src/bridges_message/pangoro.rs
+++ b/node/runtime/pangolin/src/bridges_message/pangoro.rs
@@ -156,7 +156,7 @@ impl ThisChainWithMessages for Pangolin {
 	type Call = Call;
 
 	fn is_outbound_lane_enabled(lane: &LaneId) -> bool {
-		*lane == [0, 0, 0, 0] || *lane == [0, 0, 0, 1] || *lane == PANGORO_PANGOLIN_LANE
+		*lane == PANGORO_PANGOLIN_LANE
 	}
 
 	fn maximal_pending_messages_at_outbound_lane() -> MessageNonce {

--- a/node/runtime/pangoro/src/bridges_message/pangolin.rs
+++ b/node/runtime/pangoro/src/bridges_message/pangolin.rs
@@ -158,7 +158,7 @@ impl ThisChainWithMessages for Pangoro {
 	type Call = Call;
 
 	fn is_outbound_lane_enabled(lane: &LaneId) -> bool {
-		*lane == [0, 0, 0, 0] || *lane == [0, 0, 0, 1] || *lane == PANGORO_PANGOLIN_LANE
+		*lane == PANGORO_PANGOLIN_LANE
 	}
 
 	fn maximal_pending_messages_at_outbound_lane() -> MessageNonce {


### PR DESCRIPTION
Part of #1403. If someone sends cross-chain messages to those unmonitored lanes, nothing will be seen in the target chain.

Bridger Lane Config Reference: https://github.com/darwinia-network/bridger/blob/master/.maintain/config/bridge-pangolin-pangolinparachain.toml