### PR TITLE
Release `v2.9.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-balances"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "darwinia-support",
  "frame-support",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-bridge-ethereum"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "array-bytes",
  "blake2-rfc",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-ecdsa-authority"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "array-bytes",
  "ethabi",
@@ -1481,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-ethereum"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "array-bytes",
  "bp-message-dispatch",
@@ -1516,7 +1516,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-evm"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "array-bytes",
  "darwinia-balances",
@@ -1543,7 +1543,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-evm-precompile-bls12-381"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "darwinia-evm",
  "darwinia-evm-precompile-utils",
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-evm-precompile-bridge-s2s"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "bp-message-dispatch",
  "bp-runtime",
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-evm-precompile-dispatch"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "darwinia-evm",
  "darwinia-evm-precompile-utils",
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-evm-precompile-kton"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "darwinia-balances",
  "darwinia-ethereum",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-evm-precompile-state-storage"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "array-bytes",
  "darwinia-balances",
@@ -1643,7 +1643,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-evm-precompile-transfer"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "darwinia-evm",
  "darwinia-evm-precompile-utils",
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-evm-precompile-utils"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "array-bytes",
  "darwinia-ethereum",
@@ -1677,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-evm-precompile-utils-macro"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "fp-evm",
  "num_enum",
@@ -1689,7 +1689,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-header-mmr"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "array-bytes",
  "ckb-merkle-mountain-range",
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-message-gadget"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "array-bytes",
  "darwinia-ethereum",
@@ -1723,7 +1723,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-relay-authority"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "array-bytes",
  "darwinia-balances",
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-relayer-game"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "darwinia-balances",
  "darwinia-support",
@@ -1763,7 +1763,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-staking"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "darwinia-balances",
  "darwinia-support",
@@ -1793,7 +1793,7 @@ dependencies = [
 
 [[package]]
 name = "darwinia-support"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1936,7 +1936,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dp-asset"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "ethereum-types",
  "parity-scale-codec",
@@ -1946,7 +1946,7 @@ dependencies = [
 
 [[package]]
 name = "dp-contract"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "array-bytes",
  "bp-messages",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "dp-evm-trace-ext"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "ethereum-types",
  "evm-tracing-events",
@@ -1971,7 +1971,7 @@ dependencies = [
 
 [[package]]
 name = "dp-evm-tracer"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "dp-evm-trace-ext",
  "ethereum-types",
@@ -1988,14 +1988,14 @@ dependencies = [
 
 [[package]]
 name = "dp-message"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "array-bytes",
 ]
 
 [[package]]
 name = "dp-relayer-game"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -2006,7 +2006,7 @@ dependencies = [
 
 [[package]]
 name = "dp-s2s"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "array-bytes",
  "bp-message-dispatch",
@@ -2021,7 +2021,7 @@ dependencies = [
 
 [[package]]
 name = "drml"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "drml-node-service",
  "drml-primitives",
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "drml-common-runtime"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "bp-messages",
  "bridge-runtime-common",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "drml-node-service"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "drml-primitives"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "darwinia-support",
  "sp-core",
@@ -2148,7 +2148,7 @@ dependencies = [
 
 [[package]]
 name = "drml-rpc"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "darwinia-ethereum",
  "drml-primitives",
@@ -2382,7 +2382,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-primitives"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "array-bytes",
  "ethash",
@@ -2991,7 +2991,7 @@ dependencies = [
 
 [[package]]
 name = "from-substrate-issuing"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "array-bytes",
  "bp-message-dispatch",
@@ -4882,7 +4882,7 @@ checksum = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
 
 [[package]]
 name = "merkle-patricia-trie"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "array-bytes",
  "criterion",
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "module-transaction-pause"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "darwinia-balances",
  "darwinia-support",
@@ -6257,7 +6257,7 @@ dependencies = [
 
 [[package]]
 name = "pangolin-runtime"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "array-bytes",
  "beefy-primitives",
@@ -6373,7 +6373,7 @@ dependencies = [
 
 [[package]]
 name = "pangoro-runtime"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "array-bytes",
  "beefy-primitives",
@@ -9868,7 +9868,7 @@ dependencies = [
 
 [[package]]
 name = "template-runtime"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "darwinia-balances",
  "darwinia-ethereum",
@@ -10037,7 +10037,7 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "to-ethereum-backing"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "array-bytes",
  "darwinia-balances",
@@ -10068,7 +10068,7 @@ dependencies = [
 
 [[package]]
 name = "to-parachain-backing"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "array-bytes",
  "bp-message-dispatch",
@@ -10087,7 +10087,7 @@ dependencies = [
 
 [[package]]
 name = "to-substrate-backing"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "array-bytes",
  "bp-message-dispatch",
@@ -10115,7 +10115,7 @@ dependencies = [
 
 [[package]]
 name = "to-tron-backing"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/frame/balances/Cargo.toml
+++ b/frame/balances/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "darwinia-balances"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/frame/bridge/ecdsa-authority/Cargo.toml
+++ b/frame/bridge/ecdsa-authority/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "darwinia-ecdsa-authority"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/frame/bridge/ethereum/Cargo.toml
+++ b/frame/bridge/ethereum/Cargo.toml
@@ -8,7 +8,7 @@ license     = "GPL-3.0"
 name        = "darwinia-bridge-ethereum"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/frame/bridge/message-gadget/Cargo.toml
+++ b/frame/bridge/message-gadget/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "darwinia-message-gadget"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/frame/bridge/relay-authority/Cargo.toml
+++ b/frame/bridge/relay-authority/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "darwinia-relay-authority"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/frame/bridge/relayer-game/Cargo.toml
+++ b/frame/bridge/relayer-game/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "darwinia-relayer-game"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/frame/dvm/ethereum/Cargo.toml
+++ b/frame/dvm/ethereum/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "darwinia-ethereum"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/frame/dvm/evm/Cargo.toml
+++ b/frame/dvm/evm/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "darwinia-evm"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/frame/dvm/evm/precompiles/bls12381/Cargo.toml
+++ b/frame/dvm/evm/precompiles/bls12381/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "darwinia-evm-precompile-bls12-381"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/frame/dvm/evm/precompiles/bridge/s2s/Cargo.toml
+++ b/frame/dvm/evm/precompiles/bridge/s2s/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "darwinia-evm-precompile-bridge-s2s"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/frame/dvm/evm/precompiles/dispatch/Cargo.toml
+++ b/frame/dvm/evm/precompiles/dispatch/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "darwinia-evm-precompile-dispatch"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 
 [dependencies]

--- a/frame/dvm/evm/precompiles/kton/Cargo.toml
+++ b/frame/dvm/evm/precompiles/kton/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "darwinia-evm-precompile-kton"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/frame/dvm/evm/precompiles/state-storage/Cargo.toml
+++ b/frame/dvm/evm/precompiles/state-storage/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "darwinia-evm-precompile-state-storage"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/frame/dvm/evm/precompiles/transfer/Cargo.toml
+++ b/frame/dvm/evm/precompiles/transfer/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "darwinia-evm-precompile-transfer"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/frame/dvm/evm/precompiles/utils/Cargo.toml
+++ b/frame/dvm/evm/precompiles/utils/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "darwinia-evm-precompile-utils"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/frame/dvm/evm/precompiles/utils/macro/Cargo.toml
+++ b/frame/dvm/evm/precompiles/utils/macro/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "darwinia-evm-precompile-utils-macro"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [lib]
 proc-macro = true

--- a/frame/header-mmr/Cargo.toml
+++ b/frame/header-mmr/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "darwinia-header-mmr"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/frame/staking/Cargo.toml
+++ b/frame/staking/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "darwinia-staking"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/frame/support/Cargo.toml
+++ b/frame/support/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "darwinia-support"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/frame/transaction-pause/Cargo.toml
+++ b/frame/transaction-pause/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Acala Developers"]
 edition = "2021"
 name    = "module-transaction-pause"
-version = "2.9.1"
+version = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/frame/wormhole/backing/ethereum/Cargo.toml
+++ b/frame/wormhole/backing/ethereum/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "to-ethereum-backing"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/frame/wormhole/backing/parachain/Cargo.toml
+++ b/frame/wormhole/backing/parachain/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "to-parachain-backing"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/frame/wormhole/backing/s2s/Cargo.toml
+++ b/frame/wormhole/backing/s2s/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "to-substrate-backing"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/frame/wormhole/backing/tron/Cargo.toml
+++ b/frame/wormhole/backing/tron/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "to-tron-backing"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/frame/wormhole/issuing/s2s/Cargo.toml
+++ b/frame/wormhole/issuing/s2s/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "from-substrate-issuing"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -8,7 +8,7 @@ license     = "GPL-3.0"
 name        = "drml"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 # TODO: Consider rename this repo to darwinia-runtime-module-library
 [[bin]]

--- a/node/primitives/Cargo.toml
+++ b/node/primitives/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "drml-primitives"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # paritytech

--- a/node/rpc/Cargo.toml
+++ b/node/rpc/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "drml-rpc"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/node/runtime/common/Cargo.toml
+++ b/node/runtime/common/Cargo.toml
@@ -6,7 +6,7 @@ homepage    = "https://darwinia.network"
 license     = "GPL-3.0"
 name        = "drml-common-runtime"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/node/runtime/pangolin/Cargo.toml
+++ b/node/runtime/pangolin/Cargo.toml
@@ -7,7 +7,7 @@ license    = "GPL-3.0"
 name       = "pangolin-runtime"
 readme     = "README.md"
 repository = "https://github.com/darwinia-network/darwinia-common"
-version    = "2.9.1"
+version    = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/node/runtime/pangolin/src/lib.rs
+++ b/node/runtime/pangolin/src/lib.rs
@@ -123,7 +123,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: sp_runtime::create_runtime_str!("Pangolin"),
 	impl_name: sp_runtime::create_runtime_str!("Pangolin"),
 	authoring_version: 0,
-	spec_version: 2_9_01_0,
+	spec_version: 2_9_02_0,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 0,

--- a/node/runtime/pangoro/Cargo.toml
+++ b/node/runtime/pangoro/Cargo.toml
@@ -7,7 +7,7 @@ license    = "GPL-3.0"
 name       = "pangoro-runtime"
 readme     = "README.md"
 repository = "https://github.com/darwinia-network/darwinia-common"
-version    = "2.9.1"
+version    = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/node/runtime/pangoro/src/lib.rs
+++ b/node/runtime/pangoro/src/lib.rs
@@ -93,7 +93,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: sp_runtime::create_runtime_str!("Pangoro"),
 	impl_name: sp_runtime::create_runtime_str!("Pangoro"),
 	authoring_version: 0,
-	spec_version: 2_9_01_0,
+	spec_version: 2_9_02_0,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 0,

--- a/node/runtime/template/Cargo.toml
+++ b/node/runtime/template/Cargo.toml
@@ -7,7 +7,7 @@ license    = "GPL-3.0"
 name       = "template-runtime"
 readme     = "README.md"
 repository = "https://github.com/darwinia-network/darwinia-common"
-version    = "2.9.1"
+version    = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "drml-node-service"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/primitives/asset/Cargo.toml
+++ b/primitives/asset/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "dp-asset"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/primitives/contract/Cargo.toml
+++ b/primitives/contract/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "dp-contract"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/primitives/ethereum/Cargo.toml
+++ b/primitives/ethereum/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "ethereum-primitives"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/primitives/evm-trace/ext/Cargo.toml
+++ b/primitives/evm-trace/ext/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "dp-evm-trace-ext"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common/"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/primitives/evm-trace/tracer/Cargo.toml
+++ b/primitives/evm-trace/tracer/Cargo.toml
@@ -6,7 +6,7 @@ homepage    = "https://darwinia.network"
 license     = "GPL-3.0"
 name        = "dp-evm-tracer"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/primitives/merkle-patricia-trie/Cargo.toml
+++ b/primitives/merkle-patricia-trie/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "merkle-patricia-trie"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [[bench]]
 harness = false

--- a/primitives/message/Cargo.toml
+++ b/primitives/message/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "dp-message"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 

--- a/primitives/relayer-game/Cargo.toml
+++ b/primitives/relayer-game/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "dp-relayer-game"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io

--- a/primitives/s2s/Cargo.toml
+++ b/primitives/s2s/Cargo.toml
@@ -7,7 +7,7 @@ license     = "GPL-3.0"
 name        = "dp-s2s"
 readme      = "README.md"
 repository  = "https://github.com/darwinia-network/darwinia-common"
-version     = "2.9.1"
+version     = "2.9.2"
 
 [dependencies]
 # crates.io


### PR DESCRIPTION
I tried to run the result of `try-runtime` test locally, but no luck. Not too many changes between this and the last version. 

```rs
$ ./target/release/drml try-runtime --chain pangoro-dev on-runtime-upgrade live -u wss://pangoro-rpc.darwinia.network
2022-08-19 11:54:09 `pallet_timestamp::UnixTime::now` is called at genesis, invalid value returned: 0    
Error: Input("failed to build ws client")
2022-08-19 11:54:09 [0] 💸 generated 1 npos voters, 1 from validators and 0 nominators    
2022-08-19 11:54:09 [0] 💸 generated 1 npos voters, 1 from validators and 0 nominators    
2022-08-19 11:54:09 [0] 💸 new validator set of size 1 has been processed for era 1    
```