### PR TITLE
Replace `MaxUsableBalanceFromRelayer` with `BlockGasLimit`

### DIFF
--- a/frame/dvm/ethereum/src/mock.rs
+++ b/frame/dvm/ethereum/src/mock.rs
@@ -260,28 +260,26 @@ impl CallValidate<AccountId32, Origin, Call> for CallValidator {
 			Call::Ethereum(darwinia_ethereum::Call::message_transact { transaction: tx }) =>
 				match tx {
 					Transaction::Legacy(t) => {
+						ensure!(t.value.is_zero(), "Only non-payable transaction supported.");
+						ensure!(
+							t.gas_limit <= <Test as darwinia_evm::Config>::BlockGasLimit::get(),
+							"Tx gas limit over block limit"
+						);
+
 						// Use fixed gas price now.
 						let gas_price =
 							<Test as darwinia_evm::Config>::FeeCalculator::min_gas_price();
 						let fee = t.gas_limit.saturating_mul(gas_price);
 
 						// Ensure the relayer's account has enough balance to withdraw.
-						ensure!(
-							evm_ensure_can_withdraw(
-								relayer_account,
-								cmp::min(
-									fee,
-									decimal_convert(
-										MaxUsableBalanceFromRelayer::get().into(),
-										None
-									)
-								),
-								WithdrawReasons::TRANSFER
-							)
-							.is_ok(),
+						Ok(<Test as darwinia_evm::Config>::RingBalanceAdapter::ensure_can_withdraw(
+							relayer_account,
+							fee,
+							WithdrawReasons::all(),
+						)
+						.map_err(|_| {
 							TransactionValidityError::Invalid(InvalidTransaction::Payment)
-						);
-						Ok(())
+						})?)
 					},
 					_ => Ok(()),
 				},
@@ -300,45 +298,22 @@ impl CallValidate<AccountId32, Origin, Call> for CallValidator {
 				match origin.caller() {
 					OriginCaller::Ethereum(RawOrigin::EthereumTransaction(id)) => match tx {
 						Transaction::Legacy(t) => {
-							// Only non-payable call supported.
-							if t.value != U256::zero() {
-								return Err(TransactionValidityError::Invalid(
-									InvalidTransaction::Payment,
-								));
-							}
 							let gas_price =
 								<Test as darwinia_evm::Config>::FeeCalculator::min_gas_price();
 							let fee = t.gas_limit.saturating_mul(gas_price);
-
-							// MaxUsableBalanceFromRelayer is the cap limitation for fee in case
-							// gas_limit is too large for relayer
-							if fee
-								> decimal_convert(MaxUsableBalanceFromRelayer::get().into(), None)
-							{
-								return Err(TransactionValidityError::Invalid(
-									InvalidTransaction::Custom(2u8),
-								));
-							}
-
-							// Already done `evm_ensure_can_withdraw` in
-							// check_receiving_before_dispatch
 							let derived_substrate_address =
 								<Test as darwinia_evm::Config>::IntoAccountId::derive_substrate_address(id);
 
-							let result =
-								<Test as darwinia_evm::Config>::RingBalanceAdapter::evm_transfer(
-									&relayer_account,
-									&derived_substrate_address,
-									fee,
-								);
-
-							if result.is_err() {
-								return Err(TransactionValidityError::Invalid(
-									InvalidTransaction::Custom(3u8),
-								));
-							}
-
-							Ok(())
+							// The balance validation already has been done in the
+							// `check_receiving_before_dispatch`.
+							<Test as darwinia_evm::Config>::RingBalanceAdapter::evm_transfer(
+								&relayer_account,
+								&derived_substrate_address,
+								fee,
+							)
+							.map_err(|_| {
+								TransactionValidityError::Invalid(InvalidTransaction::Custom(3))
+							})
 						},
 						_ =>
 							Err(TransactionValidityError::Invalid(InvalidTransaction::Custom(1u8))),
@@ -415,9 +390,7 @@ fn evm_ensure_can_withdraw(
 
 	Ok(())
 }
-frame_support::parameter_types! {
-	pub const MaxUsableBalanceFromRelayer: Balance = 100;
-}
+
 impl pallet_bridge_dispatch::Config for Test {
 	type AccountIdConverter = AccountIdConverter;
 	type BridgeMessageId = BridgeMessageId;

--- a/node/runtime/pangolin/src/pallets/bridge_dispatch.rs
+++ b/node/runtime/pangolin/src/pallets/bridge_dispatch.rs
@@ -29,7 +29,7 @@ impl CallValidate<bp_pangolin::AccountId, Origin, Call> for CallValidator {
 					Transaction::Legacy(t) => {
 						ensure!(t.value.is_zero(), "Only non-payable transaction supported.");
 						ensure!(
-							t.gas_limit < <Runtime as darwinia_evm::Config>::BlockGasLimit::get(),
+							t.gas_limit <= <Runtime as darwinia_evm::Config>::BlockGasLimit::get(),
 							"Tx gas limit over block limit"
 						);
 

--- a/node/runtime/pangolin/src/pallets/bridge_dispatch.rs
+++ b/node/runtime/pangolin/src/pallets/bridge_dispatch.rs
@@ -14,12 +14,8 @@ use bp_message_dispatch::{CallValidate, Everything, IntoDispatchOrigin as IntoDi
 use bp_messages::{LaneId, MessageNonce};
 use darwinia_ethereum::{RawOrigin, Transaction};
 use darwinia_evm::CurrencyAdapt;
-use darwinia_support::evm::{decimal_convert, DeriveEthereumAddress, DeriveSubstrateAddress};
+use darwinia_support::evm::{DeriveEthereumAddress, DeriveSubstrateAddress};
 use pallet_bridge_dispatch::Config;
-
-frame_support::parameter_types! {
-	pub const MaxUsableBalanceFromRelayer: Balance = 100 * COIN;
-}
 
 pub struct CallValidator;
 impl CallValidate<bp_pangolin::AccountId, Origin, Call> for CallValidator {
@@ -31,6 +27,12 @@ impl CallValidate<bp_pangolin::AccountId, Origin, Call> for CallValidator {
 			Call::Ethereum(darwinia_ethereum::Call::message_transact { transaction: tx }) =>
 				match tx {
 					Transaction::Legacy(t) => {
+						ensure!(t.value.is_zero(), "Only non-payable transaction supported.");
+						ensure!(
+							t.gas_limit < <Runtime as darwinia_evm::Config>::BlockGasLimit::get(),
+							"Tx gas limit over block limit"
+						);
+
 						let gas_price =
 							<Runtime as darwinia_evm::Config>::FeeCalculator::min_gas_price();
 						let fee = t.gas_limit.saturating_mul(gas_price);
@@ -39,7 +41,7 @@ impl CallValidate<bp_pangolin::AccountId, Origin, Call> for CallValidator {
 						// reject the call before dispatch.
 						Ok(<Runtime as darwinia_evm::Config>::RingBalanceAdapter::ensure_can_withdraw(
 							relayer_account,
-							fee.min(decimal_convert(MaxUsableBalanceFromRelayer::get(), None)),
+							fee,
 							WithdrawReasons::all(),
 						).map_err(|_| TransactionValidityError::Invalid(InvalidTransaction::Payment))?)
 					},
@@ -60,28 +62,14 @@ impl CallValidate<bp_pangolin::AccountId, Origin, Call> for CallValidator {
 				match origin.caller() {
 					OriginCaller::Ethereum(RawOrigin::EthereumTransaction(id)) => match tx {
 						Transaction::Legacy(t) => {
-							// Only non-payable call supported.
-							ensure!(
-								t.value.is_zero(),
-								TransactionValidityError::Invalid(InvalidTransaction::Payment,)
-							);
-
 							let gas_price =
 								<Runtime as darwinia_evm::Config>::FeeCalculator::min_gas_price();
 							let fee = t.gas_limit.saturating_mul(gas_price);
-
-							// MaxUsableBalanceFromRelayer is the cap limitation for fee in case
-							// gas_limit is too large for relayer
-							ensure!(
-								fee <= decimal_convert(MaxUsableBalanceFromRelayer::get(), None),
-								TransactionValidityError::Invalid(InvalidTransaction::Custom(2))
-							);
-
-							// Already done `evm_ensure_can_withdraw` in
-							// check_receiving_before_dispatch
 							let derived_substrate_address =
-								<Runtime as darwinia_evm::Config>::IntoAccountId::derive_substrate_address(id);
+							<Runtime as darwinia_evm::Config>::IntoAccountId::derive_substrate_address(id);
 
+							// The balance validation already has been done in the
+							// `check_receiving_before_dispatch`.
 							<Runtime as darwinia_evm::Config>::RingBalanceAdapter::evm_transfer(
 								&relayer_account,
 								&derived_substrate_address,

--- a/node/runtime/pangoro/src/pallets/bridge_dispatch.rs
+++ b/node/runtime/pangoro/src/pallets/bridge_dispatch.rs
@@ -12,7 +12,7 @@ use bp_message_dispatch::{CallValidate, IntoDispatchOrigin as IntoDispatchOrigin
 use bp_messages::{LaneId, MessageNonce};
 use darwinia_ethereum::{RawOrigin, Transaction};
 use darwinia_evm::CurrencyAdapt;
-use darwinia_support::evm::{decimal_convert, DeriveEthereumAddress, DeriveSubstrateAddress};
+use darwinia_support::evm::{DeriveEthereumAddress, DeriveSubstrateAddress};
 use pallet_bridge_dispatch::Config;
 
 pub struct CallValidator;
@@ -25,6 +25,12 @@ impl CallValidate<bp_pangoro::AccountId, Origin, Call> for CallValidator {
 			Call::Ethereum(darwinia_ethereum::Call::message_transact { transaction: tx }) =>
 				match tx {
 					Transaction::Legacy(t) => {
+						ensure!(t.value.is_zero(), "Only non-payable transaction supported.");
+						ensure!(
+							t.gas_limit < <Runtime as darwinia_evm::Config>::BlockGasLimit::get(),
+							"Tx gas limit over block limit"
+						);
+
 						// Use fixed gas price now.
 						let gas_price =
 							<Runtime as darwinia_evm::Config>::FeeCalculator::min_gas_price();
@@ -34,7 +40,7 @@ impl CallValidate<bp_pangoro::AccountId, Origin, Call> for CallValidator {
 						// reject the call before dispatch.
 						Ok(<Runtime as darwinia_evm::Config>::RingBalanceAdapter::ensure_can_withdraw(
 							relayer_account,
-							fee.min(decimal_convert(MaxUsableBalanceFromRelayer::get(), None)),
+							fee,
 							WithdrawReasons::all(),
 						).map_err(|_| TransactionValidityError::Invalid(InvalidTransaction::Payment))?)
 					},
@@ -55,29 +61,15 @@ impl CallValidate<bp_pangoro::AccountId, Origin, Call> for CallValidator {
 				match origin.caller() {
 					OriginCaller::Ethereum(RawOrigin::EthereumTransaction(id)) => match tx {
 						Transaction::Legacy(t) => {
-							// Only non-payable call supported.
-							ensure!(
-								t.value.is_zero(),
-								TransactionValidityError::Invalid(InvalidTransaction::Payment,)
-							);
-
 							// Use fixed gas price now.
 							let gas_price =
 								<Runtime as darwinia_evm::Config>::FeeCalculator::min_gas_price();
 							let fee = t.gas_limit.saturating_mul(gas_price);
-
-							// MaxUsableBalanceFromRelayer is the cap limitation for fee in case
-							// gas_limit is too large for relayer
-							ensure!(
-								fee <= decimal_convert(MaxUsableBalanceFromRelayer::get(), None),
-								TransactionValidityError::Invalid(InvalidTransaction::Custom(2))
-							);
-
-							// Already done `evm_ensure_can_withdraw` in
-							// check_receiving_before_dispatch
 							let derived_substrate_address =
 								<Runtime as darwinia_evm::Config>::IntoAccountId::derive_substrate_address(id);
 
+							// The balance validation already has been done in the
+							// `check_receiving_before_dispatch`.
 							<Runtime as darwinia_evm::Config>::RingBalanceAdapter::evm_transfer(
 								&relayer_account,
 								&derived_substrate_address,

--- a/node/runtime/pangoro/src/pallets/bridge_dispatch.rs
+++ b/node/runtime/pangoro/src/pallets/bridge_dispatch.rs
@@ -27,7 +27,7 @@ impl CallValidate<bp_pangoro::AccountId, Origin, Call> for CallValidator {
 					Transaction::Legacy(t) => {
 						ensure!(t.value.is_zero(), "Only non-payable transaction supported.");
 						ensure!(
-							t.gas_limit < <Runtime as darwinia_evm::Config>::BlockGasLimit::get(),
+							t.gas_limit <= <Runtime as darwinia_evm::Config>::BlockGasLimit::get(),
 							"Tx gas limit over block limit"
 						);
 
@@ -61,7 +61,6 @@ impl CallValidate<bp_pangoro::AccountId, Origin, Call> for CallValidator {
 				match origin.caller() {
 					OriginCaller::Ethereum(RawOrigin::EthereumTransaction(id)) => match tx {
 						Transaction::Legacy(t) => {
-							// Use fixed gas price now.
 							let gas_price =
 								<Runtime as darwinia_evm::Config>::FeeCalculator::min_gas_price();
 							let fee = t.gas_limit.saturating_mul(gas_price);
@@ -101,10 +100,6 @@ impl IntoDispatchOriginT<bp_pangoro::AccountId, Call, Origin> for IntoDispatchOr
 			_ => frame_system::RawOrigin::Signed(id.clone()).into(),
 		}
 	}
-}
-
-frame_support::parameter_types! {
-	pub const MaxUsableBalanceFromRelayer: Balance = 100 * COIN;
 }
 
 impl Config<WithPangolinDispatch> for Runtime {


### PR DESCRIPTION
Fix #1310 

1. Replace the `MaxUsableBalanceFromRelayer` validation with `BlockGasLimit`
2. Remove the duplicated validations in `call_validate`, which has been done in the `check_receiving_before_dispatch` before dispatching.