### PR TITLE
Remove `pallet-evm`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1603,7 +1603,6 @@ dependencies = [
  "frame-support",
  "frame-system",
  "num_enum",
- "pallet-evm",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
@@ -3001,7 +3000,6 @@ dependencies = [
  "darwinia-ethereum",
  "darwinia-evm",
  "darwinia-evm-precompile-bridge-s2s",
- "darwinia-evm-precompile-dispatch",
  "darwinia-evm-precompile-utils",
  "darwinia-support",
  "dp-asset",
@@ -3016,8 +3014,6 @@ dependencies = [
  "frame-support",
  "frame-system",
  "libsecp256k1 0.5.0",
- "pallet-evm",
- "pallet-evm-precompile-simple",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
@@ -5826,32 +5822,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-npos-elections",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-evm"
-version = "6.0.0-dev"
-source = "git+https://github.com/darwinia-network/frontier?branch=darwinia-v0.12.4#72bf8c397a5921c8bdac61aa4e42cb6fd98f5c7d"
-dependencies = [
- "evm",
- "fp-evm",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "hex",
- "log",
- "pallet-balances",
- "pallet-timestamp",
- "parity-scale-codec",
- "primitive-types",
- "rlp",
- "scale-info",
- "serde",
- "sha3 0.10.2",
- "sp-core",
- "sp-io",
  "sp-runtime",
  "sp-std",
 ]
@@ -8742,16 +8712,6 @@ dependencies = [
  "digest 0.9.0",
  "keccak",
  "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "sha3"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a31480366ec990f395a61b7c08122d99bd40544fdb5abcfc1b06bb29994312c"
-dependencies = [
- "digest 0.10.3",
- "keccak",
 ]
 
 [[package]]

--- a/frame/dvm/evm/precompiles/kton/Cargo.toml
+++ b/frame/dvm/evm/precompiles/kton/Cargo.toml
@@ -41,7 +41,6 @@ sp-runtime       = { git = "https://github.com/darwinia-network/substrate", bran
 sp-std           = { git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.4" }
 # frontier
 fp-self-contained = { git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.4" }
-pallet-evm        = { git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.4" }
 
 [features]
 default = ["std"]

--- a/frame/dvm/evm/precompiles/utils/src/data/tests.rs
+++ b/frame/dvm/evm/precompiles/utils/src/data/tests.rs
@@ -28,10 +28,7 @@ fn u256_repeat_byte(byte: u8) -> U256 {
 // When debugging it is useful to display data in chunks of 32 bytes.
 #[allow(dead_code)]
 fn display_bytes(bytes: &[u8]) {
-	bytes
-		.chunks_exact(32)
-		.map(H256::from_slice)
-		.for_each(|hash| println!("{:?}", hash));
+	bytes.chunks_exact(32).map(H256::from_slice).for_each(|hash| println!("{:?}", hash));
 }
 
 #[test]
@@ -533,10 +530,7 @@ fn write_vec_bytes() {
 	let writer_output =
 		EvmDataWriter::new().write(vec![Bytes::from(&data[..]), Bytes::from(&data[..])]).build();
 
-	writer_output
-		.chunks_exact(32)
-		.map(H256::from_slice)
-		.for_each(|hash| println!("{:?}", hash));
+	writer_output.chunks_exact(32).map(H256::from_slice).for_each(|hash| println!("{:?}", hash));
 
 	// We pad data to a multiple of 32 bytes.
 	let mut padded = data.to_vec();
@@ -585,10 +579,7 @@ fn read_vec_of_bytes() {
 	let writer_output =
 		EvmDataWriter::new().write(vec![Bytes::from(&data[..]), Bytes::from(&data[..])]).build();
 
-	writer_output
-		.chunks_exact(32)
-		.map(H256::from_slice)
-		.for_each(|hash| println!("{:?}", hash));
+	writer_output.chunks_exact(32).map(H256::from_slice).for_each(|hash| println!("{:?}", hash));
 
 	let mut reader = EvmDataReader::new(&writer_output);
 	let parsed: Vec<Bytes> = reader.read().expect("to correctly parse Vec<u8>");

--- a/frame/wormhole/issuing/s2s/Cargo.toml
+++ b/frame/wormhole/issuing/s2s/Cargo.toml
@@ -44,15 +44,12 @@ libsecp256k1 = { version = "0.5", features = ["static-context", "hmac"] }
 # darwinia-network
 darwinia-balances                  = { path = "../../../balances" }
 darwinia-evm-precompile-bridge-s2s = { path = "../../../dvm/evm/precompiles/bridge/s2s" }
-darwinia-evm-precompile-dispatch   = { path = "../../../dvm/evm/precompiles/dispatch" }
 darwinia-evm-precompile-utils      = { features = ["testing"], path = "../../../dvm/evm/precompiles/utils" }
 darwinia-support                   = { features = ["testing"], path = "../../../support" }
 # paritytech
 pallet-timestamp = { git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.4" }
 # frontier
 fp-self-contained            = { git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.4" }
-pallet-evm                   = { git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.4" }
-pallet-evm-precompile-simple = { git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.4" }
 
 [features]
 default = ["std"]

--- a/frame/wormhole/issuing/s2s/src/mock.rs
+++ b/frame/wormhole/issuing/s2s/src/mock.rs
@@ -30,7 +30,6 @@ use frame_support::{
 	PalletId,
 };
 use frame_system::mocking::*;
-use pallet_evm_precompile_simple::{ECRecover, Identity, Ripemd160, Sha256};
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
@@ -46,7 +45,6 @@ use darwinia_ethereum::{
 };
 use darwinia_evm::{EVMCurrencyAdapter, EnsureAddressTruncated, SubstrateBlockHashMapping};
 use darwinia_evm_precompile_bridge_s2s::Sub2SubBridge;
-use darwinia_evm_precompile_dispatch::Dispatch;
 use darwinia_evm_precompile_utils::test_helper::{address_build, AccountInfo};
 use darwinia_support::{
 	evm::DeriveSubstrateAddress,
@@ -162,13 +160,12 @@ where
 	}
 
 	pub fn used_addresses() -> [H160; 6] {
-		[addr(1), addr(2), addr(3), addr(4), addr(24), addr(25)]
+		[addr(24)]
 	}
 }
 impl<R> PrecompileSet for MockPrecompiles<R>
 where
 	Sub2SubBridge<R, MockS2sMessageSender, ()>: Precompile,
-	Dispatch<R>: Precompile,
 	R: darwinia_evm::Config,
 {
 	fn execute(
@@ -180,17 +177,10 @@ where
 		is_static: bool,
 	) -> Option<PrecompileResult> {
 		match address {
-			// Ethereum precompiles
-			a if a == addr(1) => Some(ECRecover::execute(input, target_gas, context, is_static)),
-			a if a == addr(2) => Some(Sha256::execute(input, target_gas, context, is_static)),
-			a if a == addr(3) => Some(Ripemd160::execute(input, target_gas, context, is_static)),
-			a if a == addr(4) => Some(Identity::execute(input, target_gas, context, is_static)),
 			// Darwinia precompiles
 			a if a == addr(24) => Some(<Sub2SubBridge<R, MockS2sMessageSender, ()>>::execute(
 				input, target_gas, context, is_static,
 			)),
-			a if a == addr(25) =>
-				Some(<Dispatch<R>>::execute(input, target_gas, context, is_static)),
 			_ => None,
 		}
 	}

--- a/frame/wormhole/issuing/s2s/src/mock.rs
+++ b/frame/wormhole/issuing/s2s/src/mock.rs
@@ -159,7 +159,7 @@ where
 		Self(Default::default())
 	}
 
-	pub fn used_addresses() -> [H160; 6] {
+	pub fn used_addresses() -> [H160; 1] {
 		[addr(24)]
 	}
 }


### PR DESCRIPTION
We don't need this anymore, all the basic types that we need are in the primitive's crates.