### PR TITLE
Add runtime `multiplier_tests`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6419,6 +6419,7 @@ dependencies = [
  "sp-core",
  "sp-finality-grandpa",
  "sp-inherents",
+ "sp-io",
  "sp-npos-elections",
  "sp-offchain",
  "sp-runtime",

--- a/node/runtime/common/src/lib.rs
+++ b/node/runtime/common/src/lib.rs
@@ -53,7 +53,7 @@ pub type RingNegativeImbalance<T> = <darwinia_balances::Pallet<T, RingInstance> 
 >>::NegativeImbalance;
 
 /// Parameterized slow adjusting fee updated based on
-/// https://w3f-research.readthedocs.io/en/latest/polkadot/Token%20Economics.html#-2.-slow-adjusting-mechanism
+/// https://research.web3.foundation/en/latest/polkadot/overview/2-token-economics.html#-2.-slow-adjusting-mechanism
 pub type SlowAdjustingFeeUpdate<R> =
 	TargetedFeeAdjustment<R, TargetBlockFullness, AdjustmentVariable, MinimumMultiplier>;
 

--- a/node/runtime/pangolin/Cargo.toml
+++ b/node/runtime/pangolin/Cargo.toml
@@ -108,7 +108,6 @@ sp-block-builder                           = { default-features = false, git = "
 sp-consensus-babe                          = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.4" }
 sp-core                                    = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.4" }
 sp-inherents                               = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.4" }
-sp-io                                      = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.4" }
 sp-npos-elections                          = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.4" }
 sp-offchain                                = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.4" }
 sp-runtime                                 = { default-features = false, git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.4" }
@@ -128,6 +127,8 @@ pallet-evm-precompile-bn128   = { default-features = false, git = "https://githu
 pallet-evm-precompile-modexp  = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.4" }
 pallet-evm-precompile-simple  = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.4" }
 
+[dev-dependencies]
+sp-io = { git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.4" }
 
 [build-dependencies]
 # paritytech
@@ -232,7 +233,6 @@ std = [
 	"sp-consensus-babe/std",
 	"sp-core/std",
 	"sp-inherents/std",
-	"sp-io/std",
 	"sp-npos-elections/std",
 	"sp-offchain/std",
 	"sp-runtime/std",

--- a/node/runtime/pangolin/src/lib.rs
+++ b/node/runtime/pangolin/src/lib.rs
@@ -879,3 +879,36 @@ sp_api::impl_runtime_apis! {
 		}
 	}
 }
+
+#[cfg(test)]
+mod multiplier_tests {
+	use super::*;
+	use drml_common_runtime::{MinimumMultiplier, TargetBlockFullness};
+	use frame_support::{pallet_prelude::Weight, weights::DispatchClass};
+	use sp_runtime::traits::Convert;
+
+	fn run_with_system_weight<F>(w: Weight, mut assertions: F)
+	where
+		F: FnMut() -> (),
+	{
+		let mut t: sp_io::TestExternalities =
+			frame_system::GenesisConfig::default().build_storage::<Runtime>().unwrap().into();
+		t.execute_with(|| {
+			System::set_block_consumed_resources(w, 0);
+			assertions()
+		});
+	}
+
+	#[test]
+	fn multiplier_can_grow_from_zero() {
+		let minimum_multiplier = MinimumMultiplier::get();
+		let target = TargetBlockFullness::get()
+			* RuntimeBlockWeights::get().get(DispatchClass::Normal).max_total.unwrap();
+		// if the min is too small, then this will not change, and we are doomed forever.
+		// the weight is 1/100th bigger than target.
+		run_with_system_weight(target * 101 / 100, || {
+			let next = SlowAdjustingFeeUpdate::<Runtime>::convert(minimum_multiplier);
+			assert!(next > minimum_multiplier, "{:?} !>= {:?}", next, minimum_multiplier);
+		})
+	}
+}

--- a/node/runtime/pangoro/Cargo.toml
+++ b/node/runtime/pangoro/Cargo.toml
@@ -104,6 +104,9 @@ pallet-evm-precompile-bn128   = { default-features = false, git = "https://githu
 pallet-evm-precompile-modexp  = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.4" }
 pallet-evm-precompile-simple  = { default-features = false, git = "https://github.com/darwinia-network/frontier", branch = "darwinia-v0.12.4" }
 
+[dev-dependencies]
+sp-io = { git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.4" }
+
 [build-dependencies]
 # paritytech
 substrate-wasm-builder = { git = "https://github.com/darwinia-network/substrate", branch = "darwinia-v0.12.4" }

--- a/node/runtime/pangoro/src/lib.rs
+++ b/node/runtime/pangoro/src/lib.rs
@@ -741,3 +741,36 @@ sp_api::impl_runtime_apis! {
 		}
 	}
 }
+
+#[cfg(test)]
+mod multiplier_tests {
+	use super::*;
+	use drml_common_runtime::{MinimumMultiplier, TargetBlockFullness};
+	use frame_support::{pallet_prelude::Weight, weights::DispatchClass};
+	use sp_runtime::traits::Convert;
+
+	fn run_with_system_weight<F>(w: Weight, mut assertions: F)
+	where
+		F: FnMut() -> (),
+	{
+		let mut t: sp_io::TestExternalities =
+			frame_system::GenesisConfig::default().build_storage::<Runtime>().unwrap().into();
+		t.execute_with(|| {
+			System::set_block_consumed_resources(w, 0);
+			assertions()
+		});
+	}
+
+	#[test]
+	fn multiplier_can_grow_from_zero() {
+		let minimum_multiplier = MinimumMultiplier::get();
+		let target = TargetBlockFullness::get()
+			* RuntimeBlockWeights::get().get(DispatchClass::Normal).max_total.unwrap();
+		// if the min is too small, then this will not change, and we are doomed forever.
+		// the weight is 1/100th bigger than target.
+		run_with_system_weight(target * 101 / 100, || {
+			let next = SlowAdjustingFeeUpdate::<Runtime>::convert(minimum_multiplier);
+			assert!(next > minimum_multiplier, "{:?} !>= {:?}", next, minimum_multiplier);
+		})
+	}
+}


### PR DESCRIPTION
I found something while exploring #1251 

Fix an invalid link and introduce a multiplier runtime test from the Polkadot to ensure the config is correct. See https://github.com/paritytech/polkadot/blob/master/runtime/kusama/src/lib.rs#L2057-L2082