### PR TITLE
Exit when elector invalid

### DIFF
--- a/frame/dvm/evm/precompiles/kton/src/lib.rs
+++ b/frame/dvm/evm/precompiles/kton/src/lib.rs
@@ -99,7 +99,7 @@ where
 		is_static: bool,
 	) -> EvmResult<PrecompileOutput> {
 		let mut helper = PrecompileHelper::<Runtime>::new(input, target_gas, context, is_static);
-		let action = helper.selector().unwrap_or(Action::Name);
+		let action = helper.selector()?;
 
 		match action {
 			Action::Transfer | Action::Allowance | Action::Approve | Action::TransferFrom =>


### PR DESCRIPTION
Fix #1443  

Before:

```sh
$ curl -fsS https://pangoro-rpc.darwinia.network -d '{"id":1,"jsonrpc":"2.0","method":"eth_call","params":[{"data":"0x01ffc9a75b5e139f00000000000000000000000000000000000000000000000000000000","gas":"0x5b8d80","to":"0x0000000000000000000000000000000000000402"},"latest"]}' -H 'Content-Type: application/json' | jq
{
  "jsonrpc": "2.0",
  "result": "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000b4f4b544f4e204552433230000000000000000000000000000000000000000000",
  "id": 1
}

```

After: 

```sh
$ curl -fsS http://127.0.0.1:9933 -d '{"id":1,"jsonrpc":"2.0","method":"eth_call","params":[{"data":"0x01ffc9a75b5e139f00000000000000000000000000000000000000000000000000000000","gas":"0x5b8d80","to":"0x0000000000000000000000000000000000000402"},"latest"]}' -H 'Content-Type: application/json' | jq
{
  "jsonrpc": "2.0",
  "error": {
    "code": -32603,
    "message": "VM Exception while processing transaction: revert unknown selector",
    "data": "08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000010756e6b6e6f776e2073656c6563746f7200000000000000000000000000000000"
  },
  "id": 1
}
```

![image](https://user-images.githubusercontent.com/11801722/191247715-2ac77264-3d6a-4ec7-bb69-4ea7fa52855e.png)


