### PR TITLE
Use `nightly-2022-07-14`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel    = "nightly-2022-05-12"
+channel    = "nightly-2022-07-24"
 components = ["cargo", "clippy", "rustc", "rustfmt", "rust-src"]
 profile    = "minimal"
 targets    = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
This version was verified by polkadot-v0.9.29.

IMO, it's safe to switch to this toolchain.